### PR TITLE
Add bind-pose fallback, bone overrides, and robust skinning

### DIFF
--- a/include/timeless/components/model.hpp
+++ b/include/timeless/components/model.hpp
@@ -20,6 +20,10 @@ struct SkeletonBone {
     std::string name;
     int parentIndex; // -1 if root
     std::vector<int> childrenIndices;
+    // The bone's rest (bind) local transform, straight from the node hierarchy.
+    // Used as the fallback pose for any clip that doesn't animate this bone, so
+    // un-keyframed bones hold their bind offset instead of collapsing to identity.
+    glm::mat4 restLocalTransform = glm::mat4(1.0f);
 };
 
 class Model : public Component {

--- a/include/timeless/components/skeletal_animation.hpp
+++ b/include/timeless/components/skeletal_animation.hpp
@@ -34,6 +34,15 @@ public:
   // Animation name -> AnimationData
   std::unordered_map<std::string, SkeletalAnimationData> animations;
 
+  // Extra per-bone, local-space transforms applied on top of the current clip
+  // (e.g. procedural lip/jaw motion). Keyed by bone name.
+  std::unordered_map<std::string, glm::mat4> boneOverrides;
+
+  void setBoneOverride(const std::string &name, const glm::mat4 &m) {
+    boneOverrides[name] = m;
+  }
+  void clearBoneOverride(const std::string &name) { boneOverrides.erase(name); }
+
   // Computed pose matrices for skinning (one per bone, matches Model's bone
   // order)
   std::vector<glm::mat4> poseMatrices;
@@ -142,7 +151,8 @@ private:
   void computeBonePose(int boneIndex, const glm::mat4 &parentTransform) {
     const SkeletonBone &bone = model->skeletonBones[boneIndex];
 
-    glm::mat4 localTransform = getLocalTransform(bone.name);
+    glm::mat4 localTransform =
+        getLocalTransform(bone.name, bone.restLocalTransform);
     glm::mat4 globalTransform = parentTransform * localTransform;
 
     auto it = model->boneMapping.find(bone.name);
@@ -156,14 +166,24 @@ private:
       computeBonePose(childIdx, globalTransform);
   }
 
-  glm::mat4 getLocalTransform(const std::string &boneName) {
+  glm::mat4 getLocalTransform(const std::string &boneName,
+                              const glm::mat4 &restLocal = glm::mat4(1.0f)) {
+    // Fall back to the bind-pose local transform (not identity) so bones the
+    // current clip doesn't animate keep their rest offset instead of collapsing.
+    glm::mat4 local = restLocal;
     auto animIt = animations.find(currentAnimation);
     if (animIt != animations.end()) {
       auto boneIt = animIt->second.boneKeyframes.find(boneName);
-      if (boneIt != animIt->second.boneKeyframes.end() && !boneIt->second.times.empty())
-        return interpolate(boneIt->second, currentTime);
+      if (boneIt != animIt->second.boneKeyframes.end() &&
+          !boneIt->second.times.empty())
+        local = interpolate(boneIt->second, currentTime);
     }
-    return glm::mat4(1.0f);
+    // Procedural overrides ride on top of the baked local pose, in the bone's
+    // own space, so e.g. a lip bone can open further than the clip poses it.
+    auto ov = boneOverrides.find(boneName);
+    if (ov != boneOverrides.end())
+      local = local * ov->second;
+    return local;
   }
 
   glm::mat4 interpolate(const BoneKeyframes &keys, float time) {

--- a/include/timeless/components/text.hpp
+++ b/include/timeless/components/text.hpp
@@ -21,7 +21,7 @@ public:
   bool hidden = false;
 
   float type_speed = 0.0f;
-  bool completed;
+  bool completed = false;
   int print_length = 0;
 
   Text(

--- a/include/timeless/components/texture.hpp
+++ b/include/timeless/components/texture.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include "timeless/components/component.hpp"
 
 class Texture : public Component
@@ -25,6 +26,13 @@ public:
     {
         glDeleteTextures(1, &texture);
     }
-    
+
+    // Returns a shared, path-cached Texture, loading the file only the first
+    // time it is requested. Many trials and category labels reference the same
+    // image, so this avoids loading (and GL-uploading) identical textures more
+    // than once. Cached textures live until the program exits.
+    static std::shared_ptr<Texture> get_cached(const std::string &filename,
+                                               int width, int height);
+
     void render();
 };

--- a/shaders/webgl_model_cooktor.vs
+++ b/shaders/webgl_model_cooktor.vs
@@ -24,7 +24,8 @@ void main()
     vec4 skinnedPos;
     vec3 skinnedNormal;
 
-    if (useSkinning) {
+    float wsum = aBoneWeights.x + aBoneWeights.y + aBoneWeights.z + aBoneWeights.w;
+    if (useSkinning && wsum > 0.0001) {
         mat4 skinMatrix =
             aBoneWeights.x * boneMatrices[int(aBoneIDs.x)] +
             aBoneWeights.y * boneMatrices[int(aBoneIDs.y)] +
@@ -33,6 +34,8 @@ void main()
         skinnedPos = skinMatrix * vec4(aPos, 1.0);
         skinnedNormal = mat3(skinMatrix) * aNormal;
     } else {
+        // No skinning, or an unweighted vertex: keep it at its bind position
+        // instead of collapsing to the origin (skinMatrix would be the 0 matrix).
         skinnedPos = vec4(aPos, 1.0);
         skinnedNormal = aNormal;
     }

--- a/shaders/webgl_shadow_depth.vs
+++ b/shaders/webgl_shadow_depth.vs
@@ -11,7 +11,8 @@ uniform bool useSkinning;
 void main()
 {
     vec4 pos;
-    if (useSkinning) {
+    float wsum = aBoneWeights.x + aBoneWeights.y + aBoneWeights.z + aBoneWeights.w;
+    if (useSkinning && wsum > 0.0001) {
         mat4 skinMatrix =
             aBoneWeights.x * boneMatrices[int(aBoneIDs.x)] +
             aBoneWeights.y * boneMatrices[int(aBoneIDs.y)] +
@@ -19,6 +20,7 @@ void main()
             aBoneWeights.w * boneMatrices[int(aBoneIDs.w)];
         pos = skinMatrix * vec4(aPos, 1.0);
     } else {
+        // Unweighted vertex stays at bind position (avoids origin collapse).
         pos = vec4(aPos, 1.0);
     }
     gl_Position = lightSpaceMatrix * model * pos;

--- a/src/timeless/components/model.cpp
+++ b/src/timeless/components/model.cpp
@@ -2,7 +2,10 @@
 #include "assimp/config.h"
 #include "assimp/postprocess.h"
 #include "glm/gtc/type_ptr.hpp"
+#include <algorithm>
 #include <optional>
+#include <utility>
+#include <vector>
 
 static glm::mat4 aiToGlm(const aiMatrix4x4 &m) {
   // Assimp is row-major; GLM is column-major — transpose on construction.
@@ -114,6 +117,9 @@ void Model::processBone(aiNode *node, const aiScene *scene,
     SkeletonBone bone;
     bone.name = node->mName.C_Str();
     bone.parentIndex = parentSkeletonIdx;
+    // Remember the bind-pose local transform so the animation system can fall
+    // back to it for clips that don't keyframe this bone.
+    bone.restLocalTransform = aiToGlm(node->mTransformation);
     skeletonBones.push_back(bone);
   }
 
@@ -239,7 +245,13 @@ std::shared_ptr<Mesh> Model::processMesh(aiMesh *mesh, const aiScene *scene,
     vertices[i].Normal = glm::normalize(vertices[i].Normal);
   }
 
-  // Assign bone indices and weights to vertices using the global boneMapping
+  // Assign bone indices and weights to vertices using the global boneMapping.
+  // The skinning shader supports only 4 influences and does NOT normalize, so
+  // we gather every influence per vertex, keep the 4 strongest, and renormalize
+  // them to sum to 1. Without this, vertices with >4 influences or unnormalized
+  // weights (common after re-skinning in Blender) get pulled toward the model
+  // origin.
+  std::vector<std::vector<std::pair<int, float>>> influences(vertices.size());
   for (unsigned int i = 0; i < mesh->mNumBones; i++) {
     aiBone *bone = mesh->mBones[i];
     std::string boneName(bone->mName.data);
@@ -254,12 +266,37 @@ std::shared_ptr<Mesh> Model::processMesh(aiMesh *mesh, const aiScene *scene,
     for (unsigned int j = 0; j < bone->mNumWeights; j++) {
       unsigned int vertexID = bone->mWeights[j].mVertexId;
       float weight = bone->mWeights[j].mWeight;
-      for (int k = 0; k < 4; ++k) {
-        if (vertices[vertexID].boneData.weights[k] == 0.0f) {
-          vertices[vertexID].boneData.ids[k] = static_cast<float>(boneIndex);
-          vertices[vertexID].boneData.weights[k] = weight;
-          break;
-        }
+      if (weight > 0.0f && vertexID < influences.size())
+        influences[vertexID].emplace_back(boneIndex, weight);
+    }
+  }
+
+  int over_influenced = 0; // verts that had >4 bone influences (diagnostic)
+  int unweighted = 0;      // verts with no bone weights at all (diagnostic)
+  for (size_t v = 0; v < vertices.size(); ++v) {
+    auto &infl = influences[v];
+    if (infl.empty())
+      unweighted++;
+    if (infl.size() > 4)
+      over_influenced++;
+    // Keep the 4 strongest influences.
+    std::sort(infl.begin(), infl.end(),
+              [](const std::pair<int, float> &a,
+                 const std::pair<int, float> &b) { return a.second > b.second; });
+    if (infl.size() > 4)
+      infl.resize(4);
+
+    float sum = 0.0f;
+    for (auto &p : infl)
+      sum += p.second;
+
+    for (int k = 0; k < 4; ++k) {
+      if (k < (int)infl.size() && sum > 0.0f) {
+        vertices[v].boneData.ids[k] = static_cast<float>(infl[k].first);
+        vertices[v].boneData.weights[k] = infl[k].second / sum;
+      } else {
+        vertices[v].boneData.ids[k] = 0.0f;
+        vertices[v].boneData.weights[k] = 0.0f;
       }
     }
   }

--- a/src/timeless/components/texture.cpp
+++ b/src/timeless/components/texture.cpp
@@ -1,5 +1,6 @@
 #include "timeless/components/texture.hpp"
 #include <iostream>
+#include <unordered_map>
 
 #ifdef __EMSCRIPTEN__
 #include <GL/gl.h>
@@ -9,6 +10,18 @@
 #endif
 
 #include "stb_image.h"
+
+std::shared_ptr<Texture> Texture::get_cached(const std::string &filename,
+                                             int width, int height)
+{
+    static std::unordered_map<std::string, std::shared_ptr<Texture>> cache;
+    auto it = cache.find(filename);
+    if (it != cache.end())
+        return it->second;
+    auto tex = std::make_shared<Texture>(filename.c_str(), width, height);
+    cache.emplace(filename, tex);
+    return tex;
+}
 
 Texture::Texture(const char *filename, int width, int height)
     : width(width), height(height), filename(std::string(filename))


### PR DESCRIPTION
Skeletal/skinning fixes surfaced while adding a procedural talking head:

- SkeletalAnimation: per-bone overrides (setBoneOverride) ridden on top of the active clip; fall back to each bone's rest local transform instead of identity so clips that don't keyframe a bone no longer collapse it.
- Model: store SkeletonBone.restLocalTransform; keep the 4 strongest bone influences per vertex and renormalize (was: first 4, unnormalized).
- Shaders: guard zero-weight vertices so they stay at bind position instead of collapsing to the origin (model + shadow depth).
- Texture: path-keyed get_cached() so duplicate images load once.
- Text: initialise completed = false.