### PR TITLE
Migrate windowing/input from GLFW to SDL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 wasm-build
+build-wasm
 
 # CodeQL analysis files
 _codeql_detected_source_root

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/glfw"]
-	path = vendor/glfw
-	url = https://github.com/glfw/glfw
 [submodule "vendor/cereal"]
 	path = vendor/cereal
 	url = https://github.com/USCiLab/cereal

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/assimp"]
 	path = vendor/assimp
 	url = https://github.com/assimp/assimp.git
+[submodule "vendor/sdl"]
+	path = vendor/sdl
+	url = https://github.com/libsdl-org/SDL.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,16 @@ set_property(
 
 if(EMSCRIPTEN)
   message(STATUS "EMSCIRPTEN BUILD!")
-  # 1. Force ALL sub-projects (Assimp, GLM, etc.) to use pthreads
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+  # Threading must be CONSISTENT across every translation unit (engine, vendored
+  # libs like Assimp/GLM, and the consuming game) and match the link mode.
+  # Emscripten forbids mixing -pthread and non-pthread objects: they disagree on
+  # the memory model (shared vs non-shared), atomics and TLS layout, which the
+  # optimizer turns into miscompiled code at -O2/-O3. So only add -pthread when
+  # actually building threaded; a single-threaded build must have it nowhere.
+  if(EMSCRIPTEN_PTHREADS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+  endif()
 
   set(CMAKE_EXECUTABLE_SUFFIX ".html")
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glm)
@@ -153,7 +160,7 @@ else()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glad)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glm)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/freetype2)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/cereal)
+  # add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/cereal)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/fmod)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/assimp)
 
@@ -173,7 +180,8 @@ else()
   # PROPERTIES SUFFIX ".html"
   # LINK_FLAGS " -O3 -sFULL_ES3 -sUSE_SDL=2 -sUSE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue'] --preload-file Assets")
   # target_include_directories(${PROJECT_NAME} INTERFACE src/)
-  target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/sdl/include vendor/glad/include vendor/freetype2/include vendor/glm vendor/stb_image/ vendor/cereal/include)
+  # target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/sdl/include vendor/glad/include vendor/freetype2/include vendor/glm vendor/stb_image/ vendor/cereal/include)
+  target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/sdl/include vendor/glad/include vendor/freetype2/include vendor/glm vendor/stb_image/)
 
   # target_include_directories(${PROJECT_NAME} INTERFACE src/)
   target_link_libraries(${PROJECT_NAME} glad SDL2-static glm freetype assimp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ if(EMSCRIPTEN)
     )
     target_link_options(${PROJECT_NAME} PUBLIC
       -sALLOW_MEMORY_GROWTH=1
+      # With --shared-memory (pthreads) the ~20MB of --embed-file Assets pushes
+      # static data past the default 16MB initial-memory floor, so raise it.
+      # 64MB = ~21.5MB static + headroom for the runtime heap; growth covers the
+      # rest. (Not needed in the single-threaded branch, which grows cheaply.)
+      -sINITIAL_MEMORY=67108864
       -sEXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue']
       -sUSE_FREETYPE=1
       -sUSE_SDL=2
@@ -120,6 +125,14 @@ if(EMSCRIPTEN)
       --embed-file Assets
     )
   endif()
+
+  # Default web shell (canvas scaling, fullscreen, audio start-gate) for every
+  # game that links timeless. PUBLIC so it propagates to the consuming
+  # executable's link; a game can override it by adding its own --shell-file
+  # later (the last --shell-file wins). See web/README.md.
+  target_link_options(${PROJECT_NAME} PUBLIC
+    --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/web/shell.html)
+
   target_link_libraries(${PROJECT_NAME} glm assimp)
   # FMOD lives only in the audio module.
   target_link_libraries(${PROJECT_NAME}-audio PUBLIC fmod fmod_studio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,12 @@ if(EMSCRIPTEN)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
   target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/freetype2/include vendor/glm vendor/stb_image/)
 
+  # The Emscripten SDL2 port must be activated at COMPILE time too: its bundled
+  # <SDL.h> is a stub that errors unless -sUSE_SDL=2 is present while compiling
+  # (link-time alone is not enough). PUBLIC so consumers compiling against our
+  # headers (which pull in <SDL.h> transitively) get it as well.
+  target_compile_options(${PROJECT_NAME} PUBLIC -sUSE_SDL=2)
+
   if(EMSCRIPTEN_PTHREADS)
     target_compile_options(${PROJECT_NAME} PUBLIC
       -pthread
@@ -90,7 +96,7 @@ if(EMSCRIPTEN)
       -sALLOW_MEMORY_GROWTH=1
       -sEXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue']
       -sUSE_FREETYPE=1
-      -sUSE_GLFW=3
+      -sUSE_SDL=2
       # --use-port=contrib.glfw3
       -sMIN_WEBGL_VERSION=2
       -sMAX_WEBGL_VERSION=2
@@ -105,7 +111,7 @@ if(EMSCRIPTEN)
       -sALLOW_MEMORY_GROWTH=1
       -sEXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue']
       -sUSE_FREETYPE=1
-      -sUSE_GLFW=3
+      -sUSE_SDL=2
       # --use-port=contrib.glfw3
       -sMIN_WEBGL_VERSION=2
       -sMAX_WEBGL_VERSION=2
@@ -126,15 +132,11 @@ else()
     # SET(CMAKE_INSTALL_RPATH @loader_path/../Framework)
   endif()
 
-  if(LINUX)
-    set(GLFW_BUILD_WAYLAND OFF)
-    set(GLFW_BUILD_X11 ON)
-  endif()
-
-  # set(GLFW_LIBRARY_TYPE SHARED)
-
-  # add_executable(${PROJECT_NAME} MACOSX_BUNDLE src/main.cpp)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glfw)
+  # SDL2 (vendored) replaces GLFW for windowing/input. Build the static lib only.
+  set(SDL_STATIC ON CACHE BOOL "" FORCE)
+  set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+  set(SDL_TEST OFF CACHE BOOL "" FORCE)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/sdl)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glad)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/glm)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/freetype2)
@@ -143,7 +145,7 @@ else()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vendor/assimp)
 
   # find_package(fmod)
-  include_directories("${PROJECT_BINARY_DIR}" glad/include glfw/include freetype2/include glm/include stb_image/ assimp/include)
+  include_directories("${PROJECT_BINARY_DIR}" glad/include sdl/include freetype2/include glm/include stb_image/ assimp/include)
 
   set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
@@ -156,12 +158,12 @@ else()
 
   # set_target_properties(${PROJECT_NAME}
   # PROPERTIES SUFFIX ".html"
-  # LINK_FLAGS " -O3 -sFULL_ES3 -sUSE_GLFW=3 -sUSE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue'] --preload-file Assets")
+  # LINK_FLAGS " -O3 -sFULL_ES3 -sUSE_SDL=2 -sUSE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=['cwrap','setValue','getValue'] --preload-file Assets")
   # target_include_directories(${PROJECT_NAME} INTERFACE src/)
-  target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/glfw/include vendor/glad/include vendor/freetype2/include vendor/glm vendor/stb_image/ vendor/cereal/include)
+  target_include_directories(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}" include/ src/ vendor/sdl/include vendor/glad/include vendor/freetype2/include vendor/glm vendor/stb_image/ vendor/cereal/include)
 
   # target_include_directories(${PROJECT_NAME} INTERFACE src/)
-  target_link_libraries(${PROJECT_NAME} glad glfw glm freetype assimp)
+  target_link_libraries(${PROJECT_NAME} glad SDL2-static glm freetype assimp)
   # FMOD lives only in the audio module.
   target_link_libraries(${PROJECT_NAME}-audio PUBLIC fmod fmod_studio)
 
@@ -191,7 +193,7 @@ else()
 
   if(apple)
     install(TARGETS ${PROJECT_NAME}
-          glad freetype glm glfw DESTINATION ${PROJECT_BINARY_DIR}
+          glad freetype glm SDL2-static DESTINATION ${PROJECT_BINARY_DIR}
           BUNDLE DESTINATION ${PROJECT_BINARY_DIR}
       )
     install(IMPORTED_RUNTIME_ARTIFACTS ${PROJECT_NAME})

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -186,13 +186,13 @@ public:
 		// here we can define how and when to update our systems, and call rendering functions.
 		// we can also define some boilerplate frame limiting stuff (more to come soon)
     TE::loop(
-      [&](GLFWwindow *window, ComponentManager &cm, WindowManager &wm)
+      [&](WindowManager &wm, ComponentManager &cm)
       {
           // update certain systems here, so the framerate for these are smoother.
-          // for the AI system, this is especially important, because we don't want the 
-          // ticks to update variably based on a users system. 
-          TE::get_system<MovementSystem>("MovementSystem")->update(cm, window);
-          TE::get_system<KeyboardInputSystem>("KeyboardInputSystem")->update(cm, window);
+          // for the AI system, this is especially important, because we don't want the
+          // ticks to update variably based on a users system.
+          TE::get_system<MovementSystem>("MovementSystem")->update(cm, wm);
+          TE::get_system<KeyboardInputSystem>("KeyboardInputSystem")->update(cm, wm);
           TE::get_system<NpcAiSystem>("NpcAiSystem")->update(cm);
           // TE::get_system<AnimationSystem>("AnimationSystem")->update(cm);
 
@@ -213,8 +213,8 @@ public:
           TE::get_system<RenderingSystem>("UIRenderingSystem")->render(cm, TESettings::VIEWPORT_X, TESettings::VIEWPORT_Y);
           TE::get_system<RenderingSystem>("UITextRenderingSystem")->render(cm, TESettings::VIEWPORT_X, TESettings::VIEWPORT_Y);
 
-          glfwSwapBuffers(window);
-          glfwPollEvents();
+          wm.swap_buffers();
+          wm.poll_events();
       });
   }
 };
@@ -228,13 +228,11 @@ int main()
   // Receives a function to call and some user data to provide it.
   emscripten_set_main_loop(game.loop, 0, 1);
 #else
-    while (!glfwWindowShouldClose(wm->window) && wm->running)
+    while (!wm->should_close())
     {
       game.loop();
     }
 #endif
-
-	glfwTerminate();
 
 	return 0;
 }

--- a/include/timeless/components/model.hpp
+++ b/include/timeless/components/model.hpp
@@ -41,6 +41,17 @@ public:
   float index = 0.0f;
   glm::vec4 params = glm::vec4(0.1f, 0.1f, 0.0f, 0.0f); // Example: metallic, roughness, unused, unused
 
+  // Model-space axis-aligned bounds over every mesh vertex, computed once at
+  // load. render() draws each mesh with the entity's transform->model applied
+  // straight to these same vertex positions (skinned meshes additionally go
+  // through bone matrices, which are identity at rest), so transforming this
+  // box by transform->model bounds what is actually on screen. Used for mouse
+  // picking so a hit box can cover a whole 3D model instead of a flat quad.
+  // Only meaningful when has_local_aabb is true.
+  glm::vec3 local_aabb_min = glm::vec3(0.0f);
+  glm::vec3 local_aabb_max = glm::vec3(0.0f);
+  bool has_local_aabb = false;
+
   Model(const std::string &path, std::shared_ptr<Texture> texture,
         std::shared_ptr<Shader> shader)
       : texture(texture), shader(shader) {
@@ -94,6 +105,7 @@ private:
   std::string directory;
 
   void collectBones(const aiScene* scene);
+  void compute_local_aabb();
   void loadModel(const std::string &path, bool from_blender = false);
   void loadModelFromMemory(const std::vector<uint8_t> &data, bool from_blender = false);
   void processLoadedScene();

--- a/include/timeless/components/shader_uniforms.hpp
+++ b/include/timeless/components/shader_uniforms.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+#include <unordered_map>
+
+#include <glm/glm.hpp>
+
+#include "timeless/components/component.hpp"
+
+// Per-entity shader uniform overrides, uploaded by RenderingSystem just before
+// the entity's model draws.
+//
+// Entities often SHARE a Model and Shader (e.g. every beachbod uses one cached
+// Model + the same program), so per-entity shader params can't live on those
+// shared objects — they'd clobber. This component keeps that data on the entity
+// itself instead. The engine stays generic: it uploads whatever name->value
+// pairs it's handed and never needs to know what they mean. Being a component,
+// it's destroyed with the entity, so a recycled entity id can't inherit stale
+// values.
+//
+// Note on uniform bleed: uniform values are program-global GL state, so an
+// entity that DOESN'T set a uniform inherits whatever the previous draw left.
+// Callers that share a program should therefore seed defaults (e.g. amounts at
+// 0, alpha at 1) so every draw fully specifies its own state.
+class ShaderUniforms : public Component {
+public:
+  std::unordered_map<std::string, float> floats;
+  std::unordered_map<std::string, glm::vec3> vec3s;
+
+  // When true, RenderingSystem drops depth writes for this entity's draw so a
+  // translucent model doesn't occlude geometry behind it (depth test stays on,
+  // so nearer opaque geometry still hides it).
+  bool translucent = false;
+};

--- a/include/timeless/components/sprite.hpp
+++ b/include/timeless/components/sprite.hpp
@@ -5,7 +5,7 @@
 #else
 #include <glad/glad.h>
 #endif
-#include <GLFW/glfw3.h>
+#include "timeless/input.hpp"
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>

--- a/include/timeless/components/transform.hpp
+++ b/include/timeless/components/transform.hpp
@@ -45,8 +45,13 @@ public:
     glm::quat rotation;
 
     float width, height;
-    float hit_scale_x = 1.0f; // multiplier for hit-detection box only (does not affect rendering)
-    float hit_scale_y = 1.0f; // multiplier for hit-detection box only (does not affect rendering)
+    // Multipliers for the hit-detection box only (never affect rendering).
+    // Applied to the model's own local-space extents when the entity has a
+    // Model with bounds, so 1.0 means "exactly the model" and >1 adds slack for
+    // animated poses that reach outside the bind pose.
+    float hit_scale_x = 1.0f;
+    float hit_scale_y = 1.0f;
+    float hit_scale_z = 1.0f;
     float grid_x = 0;
     float grid_y = 0;
     bool flip = false;
@@ -81,6 +86,11 @@ public:
 
     glm::vec3 get_position();
 
+    /* Current position WITHOUT consuming a queued animation frame. get_position()
+    pops the frame queue as a side effect, so read-only callers (hit tests, debug
+    draw) must use this or they steal frames from the animation. */
+    glm::vec3 peek_position() const;
+
     glm::vec3 get_position_minus_offset();
 
     /* returns position minus camera - i.e. position as if looking from
@@ -92,6 +102,11 @@ public:
     void set_position_frames(glm::vec3 from, glm::vec3 to, float speed = 1.0);
 
     void append_position_frames(glm::vec3 from, glm::vec3 to, float speed = 1.0);
+
+    /* Drop any queued position frames. get_position() prefers the queue over
+    `position`, so an owner that wants a direct write to `position` to actually
+    take effect has to discard leftovers from an animation that never drained. */
+    void clear_position_frames();
 
     void set_rotation_frames(glm::vec3 from, glm::vec3 to, float speed = 1.0);
 

--- a/include/timeless/core.hpp
+++ b/include/timeless/core.hpp
@@ -21,6 +21,9 @@
 #include <string>
 #include <functional>
 #include <iostream>
+#include <algorithm> // std::swap, std::max/min in the slab test
+#include <cmath>     // std::abs
+#include <limits>    // infinity sentinels in the slab test
 
 // --- glm used by the hit-testing helpers ---
 #include <glm/glm.hpp>
@@ -40,6 +43,7 @@
 #include "timeless/components/transform.hpp"       // Transform
 #include "timeless/components/camera.hpp"          // Camera
 #include "timeless/components/animation.hpp"       // Animation
+#include "timeless/components/model.hpp"           // Model bounds for picking
 #include "timeless/components/mouse_input_listener.hpp" // add_component<MouseInputListener<...>>
 
 namespace TE
@@ -244,33 +248,88 @@ namespace TE
       }
       return false;
     }
+    // Slab test of an infinite line (not a half-ray — callers rely on hits
+    // behind the origin, because the orthographic path below starts the line at
+    // the ortho near plane, which sits 10000 units *behind* the camera).
     //
+    // Axis-by-axis rather than the classic 1/dir form: the orthographic camera
+    // produces direction components that are exactly 0, and dividing by those
+    // yields inf (or 0/0 = NaN when the origin lands exactly on a slab face).
+    // Handling the zero case explicitly keeps degenerate axes exact.
     inline bool intersect_ray_aabb(const glm::vec3 &origin, const glm::vec3 &dir,
                                   const glm::vec3 &aabb_min, const glm::vec3 &aabb_max) {
-      float tmin = (aabb_min.x - origin.x) / dir.x;
-      float tmax = (aabb_max.x - origin.x) / dir.x;
-      if (tmin > tmax) std::swap(tmin, tmax);
+      float tmin = -std::numeric_limits<float>::infinity();
+      float tmax = std::numeric_limits<float>::infinity();
 
-      float tymin = (aabb_min.y - origin.y) / dir.y;
-      float tymax = (aabb_max.y - origin.y) / dir.y;
-      if (tymin > tymax) std::swap(tymin, tymax);
-
-      if ((tmin > tymax) || (tymin > tmax))
-        return false;
-
-      if (tymin > tmin)
-        tmin = tymin;
-      if (tymax < tmax)
-        tmax = tymax;
-
-      float tzmin = (aabb_min.z - origin.z) / dir.z;
-      float tzmax = (aabb_max.z - origin.z) / dir.z;
-      if (tzmin > tzmax) std::swap(tzmin, tzmax);
-
-      if ((tmin > tzmax) || (tzmin > tmax))
-        return false;
-
+      for (int i = 0; i < 3; ++i) {
+        if (std::abs(dir[i]) < 1e-8f) {
+          // Line is parallel to this pair of slabs: it either sits between them
+          // for its whole length or misses entirely.
+          if (origin[i] < aabb_min[i] || origin[i] > aabb_max[i])
+            return false;
+          continue;
+        }
+        float inv = 1.0f / dir[i];
+        float t1 = (aabb_min[i] - origin[i]) * inv;
+        float t2 = (aabb_max[i] - origin[i]) * inv;
+        if (t1 > t2) std::swap(t1, t2);
+        tmin = std::max(tmin, t1);
+        tmax = std::min(tmax, t2);
+        if (tmin > tmax)
+          return false;
+      }
       return true;
+    }
+
+    // World-space box to pick against. Entities carrying a 3D Model are picked
+    // against the model's real bounds pushed through transform->model — the very
+    // matrix RenderingSystem draws them with — so the hit area covers the whole
+    // model (full height included) rather than a flat quad at its origin.
+    // Sprites and anything without model bounds keep the old width/height box.
+    inline void picking_aabb(Entity entity, const std::shared_ptr<Transform>& transform,
+                             glm::vec3 &out_min, glm::vec3 &out_max) {
+      auto model = TE::get_component<Model>(entity);
+      if (model != nullptr && model->has_local_aabb) {
+        glm::vec3 lo = model->local_aabb_min;
+        glm::vec3 hi = model->local_aabb_max;
+
+        // Slack is applied in the model's own space so it scales and rotates
+        // with the model instead of skewing the world-space box.
+        glm::vec3 center = (lo + hi) * 0.5f;
+        glm::vec3 extent = (hi - lo) * 0.5f *
+                           glm::vec3(transform->hit_scale_x, transform->hit_scale_y,
+                                     transform->hit_scale_z);
+        lo = center - extent;
+        hi = center + extent;
+
+        // Bound the 8 transformed corners: the model matrix carries the
+        // isometric 45° spin and per-axis scale, so the local box is not
+        // axis-aligned once it lands in the world.
+        out_min = glm::vec3(std::numeric_limits<float>::max());
+        out_max = glm::vec3(std::numeric_limits<float>::lowest());
+        for (int i = 0; i < 8; ++i) {
+          glm::vec3 corner((i & 1) ? hi.x : lo.x,
+                           (i & 2) ? hi.y : lo.y,
+                           (i & 4) ? hi.z : lo.z);
+          glm::vec3 world = glm::vec3(transform->model * glm::vec4(corner, 1.0f));
+          out_min = glm::min(out_min, world);
+          out_max = glm::max(out_max, world);
+        }
+        return;
+      }
+
+      // peek_position(), not get_position(): the latter pops a frame off the
+      // transform's animation queue, so hit-testing would fast-forward every
+      // animated entity the mouse passes over.
+      glm::vec3 box_center = transform->peek_position();
+      float w = transform->width;
+      float h = transform->height;
+      if (transform->width == 0.0f && transform->height == 0.0f) {
+        w = transform->scale.x * transform->hit_scale_x;
+        h = transform->scale.y * transform->hit_scale_y;
+      }
+      out_min = box_center - glm::vec3(w, h, 0.0f);
+      out_max = box_center + glm::vec3(w, h, 0.0f);
     }
 
     inline bool clicked_on_perspective(MouseEvent* event, Entity entity, float zoom = 1.0f)
@@ -311,16 +370,8 @@ namespace TE
             ray_dir = -glm::normalize(camera->get_forward());
           }
 
-          // Entity bounding box (centered position, width, height)
-          glm::vec3 box_center = transform->get_position();
-          float w = transform->width;
-          float h = transform->height;
-          if(transform->width == 0.0f && transform->height == 0.0f) {
-            w = transform->scale.x * transform->hit_scale_x;
-            h = transform->scale.y * transform->hit_scale_y;
-          }
-          glm::vec3 box_min = box_center - glm::vec3(w, h, 0.0f);
-          glm::vec3 box_max = box_center + glm::vec3(w, h, 0.0f);
+          glm::vec3 box_min, box_max;
+          picking_aabb(entity, transform, box_min, box_max);
 
           return intersect_ray_aabb(near_point, ray_dir, box_min, box_max);
         }
@@ -353,6 +404,13 @@ namespace TE
     inline bool hovered_over_perspective(MouseMoveEvent *event, Entity entity,
                                          float zoom = 1.0f) {
       auto transform = TE::get_component<Transform>(entity);
+      // Match clicked_on_perspective: while an animation is playing it is the
+      // animation's root copy that gets rendered, so pick against that one or
+      // hover and click disagree mid-animation.
+      auto animation = TE::get_component<Animation>(entity);
+      if (animation != nullptr && animation->playing) {
+        transform = animation->root->transform;
+      }
       if (transform != nullptr) {
         // Get camera matrices and viewport
         auto camera = transform->camera;
@@ -382,16 +440,8 @@ namespace TE
             ray_dir = -glm::normalize(camera->get_forward());
           }
 
-          // Entity bounding box (centered position, width, height)
-          glm::vec3 box_center = transform->get_position();
-          float w = transform->width;
-          float h = transform->height;
-          if(transform->width == 0.0f && transform->height == 0.0f) {
-            w = transform->scale.x * transform->hit_scale_x;
-            h = transform->scale.y * transform->hit_scale_y;
-          }
-          glm::vec3 box_min = box_center - glm::vec3(w, h, 0.0f);
-          glm::vec3 box_max = box_center + glm::vec3(w, h, 0.0f);
+          glm::vec3 box_min, box_max;
+          picking_aabb(entity, transform, box_min, box_max);
 
           return intersect_ray_aabb(near_point, ray_dir, box_min, box_max);
         }

--- a/include/timeless/core.hpp
+++ b/include/timeless/core.hpp
@@ -33,7 +33,7 @@
 #include "timeless/event.hpp"           // MouseEvent, MouseMoveEvent
 #include "timeless/timer.hpp"           // TimerManager
 #include "timeless/managers/component_manager.hpp" // ComponentManager
-#include "timeless/managers/window_manager.hpp"    // WindowManager, glfwTerminate
+#include "timeless/managers/window_manager.hpp"    // WindowManager
 #include "timeless/systems/system.hpp"             // System
 #include "timeless/systems/mouse_input_system.hpp" // MouseInputSystem
 #include "timeless/algorithm/graph.hpp"            // Grid, Node
@@ -83,8 +83,6 @@ namespace TE
         wm.reset();
 
         std::cout << "TE Cleanup finished" << std::endl;
-        std::cout << "Terminating GLFW..." << std::endl;
-        glfwTerminate();
     }
 
     template <typename T>
@@ -211,9 +209,9 @@ namespace TE
         return wm;
     }
 
-    inline void loop(std::function<void(GLFWwindow *window, ComponentManager &cm, WindowManager &wm)> loop_func)
+    inline void loop(std::function<void(WindowManager &wm, ComponentManager &cm)> loop_func)
     {
-        loop_func(wm->window, *cm, *wm);
+        loop_func(*wm, *cm);
     }
     inline void quit()
     {

--- a/include/timeless/input.hpp
+++ b/include/timeless/input.hpp
@@ -9,7 +9,7 @@
 // Translation to the underlying backend's scancodes lives in the platform .cpp.
 // ===========================================================================
 
-namespace te {
+namespace TE {
 
 // Engine key identifiers. Values are arbitrary (the backend mapping is internal);
 // the contiguous A..Z and Num0..Num9 runs are guaranteed so callers can index
@@ -49,4 +49,4 @@ inline Key key_digit(int n) {
 // Defined in src/timeless/managers/window_manager.cpp via the SDL backend.
 double now_seconds();
 
-} // namespace te
+} // namespace TE

--- a/include/timeless/input.hpp
+++ b/include/timeless/input.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+// ===========================================================================
+// timeless/input.hpp — backend-agnostic input + timing abstraction.
+//
+// The engine no longer leaks the windowing backend (GLFW/SDL) into its public
+// API. Game code and engine systems refer to keys/buttons via these
+// engine-owned enums and query state through WindowManager::is_key_pressed().
+// Translation to the underlying backend's scancodes lives in the platform .cpp.
+// ===========================================================================
+
+namespace te {
+
+// Engine key identifiers. Values are arbitrary (the backend mapping is internal);
+// the contiguous A..Z and Num0..Num9 runs are guaranteed so callers can index
+// with arithmetic, e.g. key_digit(n) or Key(int(Key::A) + i).
+enum class Key {
+  Unknown = 0,
+
+  // Letters
+  A, B, C, D, E, F, G, H, I, J, K, L, M,
+  N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+
+  // Top-row digits
+  Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9,
+
+  // Editing / whitespace
+  Space, Enter, Escape, Tab, Backspace, Delete,
+
+  // Arrows
+  Left, Right, Up, Down,
+
+  // Modifiers
+  LeftControl, RightControl, LeftShift, RightShift, LeftAlt, RightAlt,
+};
+
+enum class MouseButton {
+  Left,
+  Right,
+  Middle,
+};
+
+// Map a 0-based digit index to its Num key (key_digit(0) == Key::Num0).
+inline Key key_digit(int n) {
+  return static_cast<Key>(static_cast<int>(Key::Num0) + n);
+}
+
+// Monotonic time in seconds since engine/platform init. Replaces glfwGetTime().
+// Defined in src/timeless/managers/window_manager.cpp via the SDL backend.
+double now_seconds();
+
+} // namespace te

--- a/include/timeless/managers/component_manager.hpp
+++ b/include/timeless/managers/component_manager.hpp
@@ -15,6 +15,7 @@
 #include "timeless/components/node.hpp"
 #include "timeless/components/particle.hpp"
 #include "timeless/components/shader.hpp"
+#include "timeless/components/shader_uniforms.hpp"
 #include "timeless/components/sprite.hpp"
 #include "timeless/components/text.hpp"
 #include "timeless/components/texture.hpp"
@@ -38,6 +39,7 @@ private:
   auto& map_for(Model*)                              { return models; }
   auto& map_for(Texture*)                            { return textures; }
   auto& map_for(Shader*)                             { return shaders; }
+  auto& map_for(ShaderUniforms*)                     { return shader_uniforms; }
   auto& map_for(Sprite*)                             { return sprites; }
   auto& map_for(Transform*)                          { return transforms; }
   auto& map_for(MouseInputListener<MouseEvent>*)     { return mouse_input_listeners; }
@@ -63,6 +65,7 @@ public:
   std::unordered_map<Entity, std::shared_ptr<Model>> models;
   std::unordered_map<Entity, std::shared_ptr<Texture>> textures;
   std::unordered_map<Entity, std::shared_ptr<Shader>> shaders;
+  std::unordered_map<Entity, std::shared_ptr<ShaderUniforms>> shader_uniforms;
   std::unordered_map<Entity, std::shared_ptr<Sprite>> sprites;
   std::unordered_map<Entity, std::shared_ptr<Transform>> transforms;
   std::unordered_map<Entity, std::shared_ptr<MouseInputListener<MouseEvent>>>
@@ -148,6 +151,7 @@ public:
       models.erase(entity);
       textures.erase(entity);
       shaders.erase(entity);
+      shader_uniforms.erase(entity);
       sprites.erase(entity);
       transforms.erase(entity);
       mouse_input_listeners.erase(entity);
@@ -181,6 +185,7 @@ public:
     models.clear();
     textures.clear();
     shaders.clear();
+    shader_uniforms.clear();
     sprites.clear();
     transforms.clear();
     mouse_input_listeners.clear();

--- a/include/timeless/managers/window_manager.hpp
+++ b/include/timeless/managers/window_manager.hpp
@@ -80,6 +80,8 @@ public:
   bool is_mouse_button_pressed(TE::MouseButton button); // replaces glfwGetMouseButton
   glm::vec2 get_cursor_position();  // current cursor in window pixels
   void set_cursor_visible(bool visible); // show/hide the OS cursor
+  void set_fullscreen(bool enabled);     // borderless-desktop fullscreen toggle
+  void set_window_size(int width, int height); // resize + recenter the OS window
 
   // Two-finger gesture deltas accumulated since the last call (and reset by it).
   // Pan is centroid movement in window pixels; pinch is the change in finger

--- a/include/timeless/managers/window_manager.hpp
+++ b/include/timeless/managers/window_manager.hpp
@@ -63,8 +63,8 @@ public:
   void swap_buffers();
   void poll_events();              // pumps backend events into engine handlers
   bool should_close();             // SDL_QUIT or TE::quit() was called
-  bool is_key_pressed(te::Key key); // polling query (replaces glfwGetKey)
-  bool is_mouse_button_pressed(te::MouseButton button); // replaces glfwGetMouseButton
+  bool is_key_pressed(TE::Key key); // polling query (replaces glfwGetKey)
+  bool is_mouse_button_pressed(TE::MouseButton button); // replaces glfwGetMouseButton
   glm::vec2 get_cursor_position();  // current cursor in window pixels
   void set_cursor_visible(bool visible); // show/hide the OS cursor
 

--- a/include/timeless/managers/window_manager.hpp
+++ b/include/timeless/managers/window_manager.hpp
@@ -6,16 +6,20 @@
 #else
 #include <glad/glad.h>
 #endif
-#include <GLFW/glfw3.h>
 #include <iostream>
 #include <memory>
 #include <vector>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+#include "timeless/input.hpp"
 #include "timeless/components/transform.hpp"
 #include "timeless/systems/mouse_input_system.hpp"
 #include "timeless/systems/event_system.hpp"
+
+// Opaque platform handle: owns the backend window + GL context. Defined only
+// in window_manager.cpp so SDL never appears in a public header.
+struct PlatformWindow;
 
 class WindowManager {
 private:
@@ -46,14 +50,23 @@ public:
 
   unsigned int ScreenVAO, ScreenVBO;
 
-  GLFWwindow *window;
-  GLFWcursor *cursor;
-
-  static void error_callback(int error, const char *description);
+  // Backend window + GL context, hidden behind an opaque handle (PIMPL).
+  std::unique_ptr<PlatformWindow> platform;
+  bool quit_requested = false;
 
   WindowManager(std::shared_ptr<ComponentManager> cm,
                 std::shared_ptr<MouseInputSystem> mis);
+  ~WindowManager();
   void cleanup();
+
+  // --- Main-loop / platform surface (backend-agnostic) ---
+  void swap_buffers();
+  void poll_events();              // pumps backend events into engine handlers
+  bool should_close();             // SDL_QUIT or TE::quit() was called
+  bool is_key_pressed(te::Key key); // polling query (replaces glfwGetKey)
+  bool is_mouse_button_pressed(te::MouseButton button); // replaces glfwGetMouseButton
+  glm::vec2 get_cursor_position();  // current cursor in window pixels
+  void set_cursor_visible(bool visible); // show/hide the OS cursor
 
   void add_framebuffer(std::shared_ptr<Shader> shader, int width = TESettings::SCREEN_X, int height = TESettings::SCREEN_Y, bool add_screen_shader = true);
   void select_framebuffer(size_t idx, bool clear = true);
@@ -62,13 +75,9 @@ public:
   void set_shader_time(std::shared_ptr<Shader> shader);
   void set_shader_mouse_position(glm::vec2 mouse_pos);
 
-  static void framebuffer_size_callback(GLFWwindow *window, int width, int height);
-  static void window_size_callback(GLFWwindow *window, int width, int height);
+  void handle_resize(int width, int height);
   void mouse_move_handler(MouseMoveEvent *event);
   void mouse_click_handler(MouseEvent *event);
   void mouse_release_handler(MouseEvent *event);
   void mouse_scroll_handler(MouseEvent *event);
-  static void cursor_position_callback(GLFWwindow *window, double xpos, double ypos);
-  static void scroll_callback(GLFWwindow *window, double xoffset, double yoffset);
-  static void mouse_button_callback(GLFWwindow *window, int button, int action, int mods);
 };

--- a/include/timeless/managers/window_manager.hpp
+++ b/include/timeless/managers/window_manager.hpp
@@ -7,6 +7,7 @@
 #include <glad/glad.h>
 #endif
 #include <iostream>
+#include <map>
 #include <memory>
 #include <vector>
 #include <glm/glm.hpp>
@@ -48,6 +49,18 @@ public:
   glm::vec2 raw_mouse_position;
   glm::vec2 shader_mouse_position;
 
+  // --- Touch gestures (iOS / any SDL touch device) ---
+  // Active fingers keyed by SDL_FingerID (stored as long long so SDL types stay
+  // out of this header), in window pixels. When exactly two are down we treat
+  // it as a pan+pinch gesture and accumulate the deltas below; callers drain
+  // them each frame via consume_touch_pan()/consume_touch_pinch().
+  std::map<long long, glm::vec2> active_touches;
+  bool two_finger_active = false;       // had exactly 2 fingers last update
+  glm::vec2 gesture_centroid{0.0f};     // last two-finger midpoint (pixels)
+  float gesture_spread = 0.0f;          // last distance between the two fingers
+  glm::vec2 touch_pan_accum{0.0f};      // unconsumed centroid movement (pixels)
+  float touch_pinch_accum = 0.0f;       // unconsumed spread change (pixels)
+
   unsigned int ScreenVAO, ScreenVBO;
 
   // Backend window + GL context, hidden behind an opaque handle (PIMPL).
@@ -68,6 +81,13 @@ public:
   glm::vec2 get_cursor_position();  // current cursor in window pixels
   void set_cursor_visible(bool visible); // show/hide the OS cursor
 
+  // Two-finger gesture deltas accumulated since the last call (and reset by it).
+  // Pan is centroid movement in window pixels; pinch is the change in finger
+  // spread (positive = fingers moved apart). Zero when fewer than two fingers
+  // are down. Poll these once per frame, like is_key_pressed.
+  glm::vec2 consume_touch_pan();
+  float consume_touch_pinch();
+
   void add_framebuffer(std::shared_ptr<Shader> shader, int width = TESettings::SCREEN_X, int height = TESettings::SCREEN_Y, bool add_screen_shader = true);
   void select_framebuffer(size_t idx, bool clear = true);
   void resize_framebuffers(int new_width, int new_height);
@@ -76,6 +96,7 @@ public:
   void set_shader_mouse_position(glm::vec2 mouse_pos);
 
   void handle_resize(int width, int height);
+  void update_touch_gesture(); // recompute two-finger pan/pinch from active_touches
   void mouse_move_handler(MouseMoveEvent *event);
   void mouse_click_handler(MouseEvent *event);
   void mouse_release_handler(MouseEvent *event);

--- a/include/timeless/scene.hpp
+++ b/include/timeless/scene.hpp
@@ -2,6 +2,8 @@
 #include "timeless/entity.hpp"
 #include "timeless/managers/component_manager.hpp"
 
+class WindowManager; // forward decl: scenes receive it by reference
+
 // Generic scene lifecycle base.
 //
 // This is an engine-level concept: a Scene is just something with an
@@ -23,15 +25,15 @@ public:
   Scene(Entity main_cam) : main_camera(main_cam) {}
   virtual ~Scene() = default;
 
-  virtual void init(GLFWwindow * /*window*/) {}
+  virtual void init(WindowManager & /*wm*/) {}
   virtual void update(float /*dt*/) {}
   virtual void remove() {}
 
   // Advance one step of initialization. Returns true when fully done.
   // Default: run init() in a single blocking step (fine for simple scenes;
   // scenes with chunked/streamed loading override this).
-  virtual bool init_step(GLFWwindow *window) {
-    init(window);
+  virtual bool init_step(WindowManager &wm) {
+    init(wm);
     return true;
   }
 
@@ -39,7 +41,7 @@ public:
   // default is a no-op so scenes that don't draw a loading screen Just Work.
   // A subclass that wants a loading screen overrides these with its own
   // (asset-dependent) implementation.
-  virtual void setup_loading_screen(GLFWwindow * /*window*/,
+  virtual void setup_loading_screen(WindowManager & /*wm*/,
                                     ComponentManager & /*cm*/) {}
   virtual void remove_loading_screen() {}
 };

--- a/include/timeless/systems/keyboard_input_system.hpp
+++ b/include/timeless/systems/keyboard_input_system.hpp
@@ -24,5 +24,5 @@ public:
 
     void notify_listener(ComponentManager &cm, KeyboardEvent *event, Entity entity);
     glm::vec4 calculate_collider(glm::vec3 position, float width, float height);
-    void update(ComponentManager &cm, GLFWwindow *window);
+    void update(ComponentManager &cm, WindowManager &wm);
 };

--- a/include/timeless/systems/mouse_input_system.hpp
+++ b/include/timeless/systems/mouse_input_system.hpp
@@ -19,5 +19,4 @@ public:
   void mouse_release_handler(ComponentManager &cm, MouseEvent *event);
   void mouse_move_handler(ComponentManager &cm, MouseMoveEvent *event);
   void mouse_scroll_handler(ComponentManager &cm, MouseEvent *event);
-  void scroll_callback(GLFWwindow *window, double xoffset, double yoffset);
 };

--- a/include/timeless/systems/movement_system.hpp
+++ b/include/timeless/systems/movement_system.hpp
@@ -36,5 +36,5 @@ public:
     void move_left(ComponentManager &cm);
     void move_down(ComponentManager &cm);
     void move_up(ComponentManager &cm);
-    void update(ComponentManager &cm, GLFWwindow *window);
+    void update(ComponentManager &cm, WindowManager &wm);
 };

--- a/include/timeless/systems/movement_system.hpp
+++ b/include/timeless/systems/movement_system.hpp
@@ -23,11 +23,34 @@ private:
     glm::vec2 x_bounds;
     glm::vec2 y_bounds;
     float walk_speed;
-    float camera_speed;
     std::array<bool, 10> keysPressed = {false, false, false, false, false, false, false, false, false, false};
+
+    // Smoothed camera pan state. The camera is driven by a velocity that eases
+    // toward the velocity the current input asks for, so key presses/releases
+    // and edge-scroll entry/exit ramp up and down instead of snapping.
+    glm::vec2 pan_velocity = glm::vec2(0.0f);
+    float zoom_target;
+    float last_applied_zoom;
 
 public:
     Entity camera;
+
+    // World units per second the camera pans at ZOOM == 1.0. The actual speed is
+    // scaled by the zoom level, so panning covers a constant distance *on screen*
+    // regardless of how far in you are: slow when zoomed in, fast when zoomed out.
+    float camera_speed = 900.0f;
+    // How strongly pan speed follows zoom. 1.0 = exactly screen-constant;
+    // lower values take the edge off panning at the extremes.
+    float zoom_pan_exponent = 1.0f;
+    // Exponential smoothing rates (1/seconds). Higher = snappier, lower = floatier.
+    float pan_smoothing = 14.0f;
+    float zoom_smoothing = 12.0f;
+    // Multiplicative zoom per scroll notch, so every notch is the same
+    // perceived step at any zoom level.
+    float zoom_step = 1.12f;
+    glm::vec2 zoom_limits = glm::vec2(0.2f, 4.0f);
+    // How far from the window edge (in pixels) edge scrolling starts ramping up.
+    float edge_margin = 40.0f;
 
     MovementSystem();
     void register_camera(Entity c);
@@ -36,5 +59,15 @@ public:
     void move_left(ComponentManager &cm);
     void move_down(ComponentManager &cm);
     void move_up(ComponentManager &cm);
-    void update(ComponentManager &cm, WindowManager &wm);
+
+    // Nudge the zoom target by a number of scroll notches (positive = zoom in).
+    // The visible TESettings::ZOOM eases toward the target in update().
+    void zoom_by(float notches);
+    // Ease toward an absolute zoom level.
+    void zoom_to(float zoom);
+    // Jump straight to a zoom level, cancelling any in-flight easing.
+    void set_zoom(float zoom);
+    float get_zoom_target() const { return zoom_target; }
+
+    void update(ComponentManager &cm, WindowManager &wm, float delta_time = 1.0f / 60.0f);
 };

--- a/include/timeless/systems/rendering_system.hpp
+++ b/include/timeless/systems/rendering_system.hpp
@@ -59,45 +59,6 @@ public:
   // of the day-cycle formula (cos(angle)*0.5+0.1).
   float ambientStrength = -1.0f;
 
-  // Per-entity sun-burn, applied as shader uniforms around the model draw, so
-  // entities sharing one Model burn individually. xyz = burn colour (albedo
-  // multiply target), w = amount 0..1. The fragment shader reddens only sunlit
-  // fragments (shadowed parts are spared). Absent entities render unburnt.
-  std::unordered_map<Entity, glm::vec4> entity_burn;
-  void set_entity_burn(Entity e, glm::vec3 color, float amount) {
-    entity_burn[e] = glm::vec4(color, amount);
-  }
-  void clear_entity_burn(Entity e) { entity_burn.erase(e); }
-
-  // Per-entity sun-tan — same mechanism as burn (xyz = tan colour, w = amount).
-  // Tan and burn stack in the shader; both only show on sunlit fragments.
-  std::unordered_map<Entity, glm::vec4> entity_tan;
-  void set_entity_tan(Entity e, glm::vec3 color, float amount) {
-    entity_tan[e] = glm::vec4(color, amount);
-  }
-  void clear_entity_tan(Entity e) { entity_tan.erase(e); }
-
-  // Per-entity "sheen" (0..1) — a freshly-oiled gloss + selection rim, used to
-  // show which bod is being lotioned. Same per-draw-uniform mechanism as burn.
-  std::unordered_map<Entity, float> entity_sheen;
-  void set_entity_sheen(Entity e, float v) { entity_sheen[e] = v; }
-  void clear_entity_sheen(Entity e) { entity_sheen.erase(e); }
-
-  // Per-entity alpha (0..1) for translucent models — the shader outputs this as
-  // the fragment alpha and the renderer drops depth writes for translucent
-  // entities so they don't occlude geometry behind them (e.g. an umbrella faded
-  // to reveal the bod underneath). Absent entities render fully opaque.
-  std::unordered_map<Entity, float> entity_alpha;
-  void set_entity_alpha(Entity e, float v) { entity_alpha[e] = v; }
-  void clear_entity_alpha(Entity e) { entity_alpha.erase(e); }
-
-  // Per-entity "pants" colour — tints just the mesh named "Pants" (flagged by the
-  // model's isPants uniform), so each bod can wear different-coloured trunks while
-  // sharing one Model. Absent entities render the mesh's own colour (white tint).
-  std::unordered_map<Entity, glm::vec3> entity_pants;
-  void set_entity_pants_color(Entity e, glm::vec3 c) { entity_pants[e] = c; }
-  void clear_entity_pants(Entity e) { entity_pants.erase(e); }
-
   // Entities that should not cast directional shadows (skipped in the depth
   // pass) — e.g. a sky sun placed near the light, which otherwise drops a stray
   // shadow on the beach.
@@ -107,6 +68,15 @@ public:
       no_shadow_cast.erase(e);
     else
       no_shadow_cast.insert(e);
+  }
+
+  // Entity IDs are recycled (see create_entity's free list), so a stale entry
+  // left here would bleed onto whatever reuses the id. Drop this entity's
+  // shadow opt-out on destruction; game-owned per-entity state cleans itself up
+  // the same way (a System whose remove_entity is called by TE::remove_entity).
+  void remove_entity(Entity e) override {
+    no_shadow_cast.erase(e);
+    System::remove_entity(e);
   }
 
   // Shadow mapping (directional light only)

--- a/include/timeless/systems/sound_system.hpp
+++ b/include/timeless/systems/sound_system.hpp
@@ -40,7 +40,7 @@ public:
   float sampling_rate = 48000;
   void register_camera(Entity c);
   void init();
-  void load_bank_files(std::string master_bank_filename = "Assets/sound/Master.bank",
+  bool load_bank_files(std::string master_bank_filename = "Assets/sound/Master.bank",
                        std::string strings_bank_filename = "Assets/sound/Master.strings.bank");
   void update(ComponentManager &cm);
   void set_parameter(const std::string &name, int value);

--- a/include/timeless/systems/system.hpp
+++ b/include/timeless/systems/system.hpp
@@ -2,6 +2,8 @@
 #include "timeless/entity.hpp"
 #include "timeless/managers/component_manager.hpp"
 
+class WindowManager; // forward decl: only referenced by reference below
+
 class System {
 public:
   std::vector<Entity> registered_entities;
@@ -11,7 +13,7 @@ public:
   virtual void clear(ComponentManager &cm);
   virtual int get_registered_entity_count();
   virtual void purge();
-  virtual void update(ComponentManager &cm, GLFWwindow *window) {}
+  virtual void update(ComponentManager &cm, WindowManager &wm) {}
   virtual void update(ComponentManager &cm) {}
   virtual void render(ComponentManager &cm, int x, int y, float zoom = 1.0,
                       int tick = 0) {}

--- a/include/timeless/timer.hpp
+++ b/include/timeless/timer.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <GLFW/glfw3.h>
+#include "timeless/input.hpp"
 #include <functional>
 
 class Timer
@@ -12,23 +12,23 @@ public:
     Timer()
     {
         secondsToWait = 1.0;
-        start = glfwGetTime();
+        start = te::now_seconds();
     }
     Timer(double secondsToWait)
         : secondsToWait(secondsToWait)
     {
-        start = glfwGetTime();
+        start = te::now_seconds();
     }
     void startTimer()
     {
-        start = glfwGetTime();
+        start = te::now_seconds();
     }
     bool pollTime()
     {
-        double current = glfwGetTime();
+        double current = te::now_seconds();
         if (current - start >= secondsToWait)
         {
-            start = glfwGetTime();
+            start = te::now_seconds();
             return true;
         }
         return false;

--- a/include/timeless/timer.hpp
+++ b/include/timeless/timer.hpp
@@ -12,23 +12,23 @@ public:
     Timer()
     {
         secondsToWait = 1.0;
-        start = te::now_seconds();
+        start = TE::now_seconds();
     }
     Timer(double secondsToWait)
         : secondsToWait(secondsToWait)
     {
-        start = te::now_seconds();
+        start = TE::now_seconds();
     }
     void startTimer()
     {
-        start = te::now_seconds();
+        start = TE::now_seconds();
     }
     bool pollTime()
     {
-        double current = te::now_seconds();
+        double current = TE::now_seconds();
         if (current - start >= secondsToWait)
         {
-            start = te::now_seconds();
+            start = TE::now_seconds();
             return true;
         }
         return false;

--- a/shaders/webgl_model_sun.vs
+++ b/shaders/webgl_model_sun.vs
@@ -1,15 +1,15 @@
-#version 100
-attribute vec3 aPos;
-attribute vec3 aNormal;
-attribute vec2 aTexCoord;
+#version 300 es
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec3 aNormal;
+layout(location = 2) in vec2 aTexCoord;
 
 uniform mat4 projection;
 uniform mat4 model;
 uniform mat4 view;
 
-varying vec2 TexCoord;
-varying vec3 Normal;
-varying vec3 FragPos;
+out vec2 TexCoord;
+out vec3 Normal;
+out vec3 FragPos;
 
 void main()
 {

--- a/src/timeless/components/model.cpp
+++ b/src/timeless/components/model.cpp
@@ -3,6 +3,7 @@
 #include "assimp/postprocess.h"
 #include "glm/gtc/type_ptr.hpp"
 #include <algorithm>
+#include <limits>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -68,6 +69,32 @@ void Model::processLoadedScene() {
     if (parentIdx != -1 && parentIdx < (int)skeletonBones.size()) {
       skeletonBones[parentIdx].childrenIndices.push_back(i);
     }
+  }
+
+  compute_local_aabb();
+}
+
+void Model::compute_local_aabb() {
+  // Vertices are stored exactly as Assimp gave them (processMesh does not bake
+  // nodeTransform in), and render() feeds them to the shader under
+  // transform->model — for skinned meshes via bone matrices that are identity
+  // at rest. So the raw vertex extents are the model-space bounds, and the
+  // result is the bind pose for animated models. Poses that reach outside it
+  // (a wide stride, a raised arm) are covered by Transform::hit_scale_*.
+  glm::vec3 lo(std::numeric_limits<float>::max());
+  glm::vec3 hi(std::numeric_limits<float>::lowest());
+  bool any = false;
+  for (const auto &mesh : meshes) {
+    for (const auto &v : mesh->vertices) {
+      lo = glm::min(lo, v.Position);
+      hi = glm::max(hi, v.Position);
+      any = true;
+    }
+  }
+  if (any) {
+    local_aabb_min = lo;
+    local_aabb_max = hi;
+    has_local_aabb = true;
   }
 }
 

--- a/src/timeless/components/quad.cpp
+++ b/src/timeless/components/quad.cpp
@@ -36,7 +36,6 @@ Quad::~Quad()
 }
 
 void Quad::attributes() {
-    std::cout << "Setting up quad attributes" << std::endl;
     // position attribute
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void *)0);
     glEnableVertexAttribArray(0);

--- a/src/timeless/components/shader.cpp
+++ b/src/timeless/components/shader.cpp
@@ -79,6 +79,18 @@ Shader::Shader(const char *vertexPath, const char *fragmentPath)
     glBindAttribLocation(ID, 1, "aTexCoords");
     glBindAttribLocation(ID, 2, "aTexCoord");
     glLinkProgram(ID);
+    {
+        // A program that fails to link (e.g. too many uniform vectors on WebGL2,
+        // where MAX_VERTEX_UNIFORM_VECTORS may be as low as 256) otherwise fails
+        // silently and renders nothing. Surface it.
+        GLint linked = 0;
+        glGetProgramiv(ID, GL_LINK_STATUS, &linked);
+        if (!linked) {
+            char infoLog[1024];
+            glGetProgramInfoLog(ID, 1024, NULL, infoLog);
+            std::cout << "ERROR::SHADER::PROGRAM::LINK_FAILED\n" << infoLog << std::endl;
+        }
+    }
     glUseProgram(ID);
     // delete the shaders as they're linked into our program now and no longer necessery
     glDeleteShader(vertex);
@@ -131,6 +143,18 @@ Shader::Shader(const std::vector<uint8_t>& vertexBuffer, const std::vector<uint8
     glBindAttribLocation(ID, 1, "aTexCoords");
     glBindAttribLocation(ID, 2, "aTexCoord");
     glLinkProgram(ID);
+    {
+        // A program that fails to link (e.g. too many uniform vectors on WebGL2,
+        // where MAX_VERTEX_UNIFORM_VECTORS may be as low as 256) otherwise fails
+        // silently and renders nothing. Surface it.
+        GLint linked = 0;
+        glGetProgramiv(ID, GL_LINK_STATUS, &linked);
+        if (!linked) {
+            char infoLog[1024];
+            glGetProgramInfoLog(ID, 1024, NULL, infoLog);
+            std::cout << "ERROR::SHADER::PROGRAM::LINK_FAILED\n" << infoLog << std::endl;
+        }
+    }
     glUseProgram(ID);
     // delete the shaders as they're linked into our program now and no longer necessery
     glDeleteShader(vertex);

--- a/src/timeless/components/sprite.cpp
+++ b/src/timeless/components/sprite.cpp
@@ -87,7 +87,7 @@ void Sprite::set_shader_sprite_uniforms(int textureUnit) {
   glUniform2fv(glGetUniformLocation(slice_shader->ID, "spriteSize"), 1,
                glm::value_ptr(spriteSize));
   glUniform1f(glGetUniformLocation(slice_shader->ID, "time"),
-              static_cast<float>(glfwGetTime()));
+              static_cast<float>(te::now_seconds()));
   // glUniform1f(glGetUniformLocation(shader->ID, "jitter"),
   // ui_jitter); glUniform1f(glGetUniformLocation(shader->ID, "jitter_speed"),
   //             ui_jitter_speed);

--- a/src/timeless/components/sprite.cpp
+++ b/src/timeless/components/sprite.cpp
@@ -87,7 +87,7 @@ void Sprite::set_shader_sprite_uniforms(int textureUnit) {
   glUniform2fv(glGetUniformLocation(slice_shader->ID, "spriteSize"), 1,
                glm::value_ptr(spriteSize));
   glUniform1f(glGetUniformLocation(slice_shader->ID, "time"),
-              static_cast<float>(te::now_seconds()));
+              static_cast<float>(TE::now_seconds()));
   // glUniform1f(glGetUniformLocation(shader->ID, "jitter"),
   // ui_jitter); glUniform1f(glGetUniformLocation(shader->ID, "jitter_speed"),
   //             ui_jitter_speed);

--- a/src/timeless/components/transform.cpp
+++ b/src/timeless/components/transform.cpp
@@ -93,6 +93,10 @@ glm::vec3 Transform::get_position() {
   return p;
 }
 
+glm::vec3 Transform::peek_position() const {
+  return positions.empty() ? position : positions.front();
+}
+
 glm::vec3 Transform::get_position_minus_offset() {
   glm::vec3 p = get_position();
   return glm::vec3((p.x - offset.x), (p.y - offset.y), p.z);
@@ -135,6 +139,11 @@ void Transform::set_position_frames(glm::vec3 from, glm::vec3 to,
     double z_l = std::lerp(from.z, to.z, i);
     positions.push(glm::vec3(x_l, y_l, z_l));
   }
+}
+
+void Transform::clear_position_frames() {
+  while (!positions.empty())
+    positions.pop();
 }
 
 void Transform::append_position_frames(glm::vec3 from, glm::vec3 to,

--- a/src/timeless/managers/window_manager.cpp
+++ b/src/timeless/managers/window_manager.cpp
@@ -1,52 +1,126 @@
 #include "timeless/managers/window_manager.hpp"
+#include <SDL.h>
 
-void WindowManager::error_callback(int error, const char *description) {
-  fprintf(stderr, "Error: %s\n", description);
+// Opaque platform handle (declared in the header). Holds the SDL window and
+// GL context; SDL types appear only inside this translation unit.
+struct PlatformWindow {
+  SDL_Window *window = nullptr;
+  SDL_GLContext gl_context = nullptr;
+  SDL_Cursor *cursor = nullptr;
+};
+
+namespace {
+// Map engine keys to SDL scancodes (used by is_key_pressed / SDL_GetKeyboardState).
+SDL_Scancode to_scancode(te::Key key) {
+  using K = te::Key;
+  switch (key) {
+    case K::A: return SDL_SCANCODE_A; case K::B: return SDL_SCANCODE_B;
+    case K::C: return SDL_SCANCODE_C; case K::D: return SDL_SCANCODE_D;
+    case K::E: return SDL_SCANCODE_E; case K::F: return SDL_SCANCODE_F;
+    case K::G: return SDL_SCANCODE_G; case K::H: return SDL_SCANCODE_H;
+    case K::I: return SDL_SCANCODE_I; case K::J: return SDL_SCANCODE_J;
+    case K::K: return SDL_SCANCODE_K; case K::L: return SDL_SCANCODE_L;
+    case K::M: return SDL_SCANCODE_M; case K::N: return SDL_SCANCODE_N;
+    case K::O: return SDL_SCANCODE_O; case K::P: return SDL_SCANCODE_P;
+    case K::Q: return SDL_SCANCODE_Q; case K::R: return SDL_SCANCODE_R;
+    case K::S: return SDL_SCANCODE_S; case K::T: return SDL_SCANCODE_T;
+    case K::U: return SDL_SCANCODE_U; case K::V: return SDL_SCANCODE_V;
+    case K::W: return SDL_SCANCODE_W; case K::X: return SDL_SCANCODE_X;
+    case K::Y: return SDL_SCANCODE_Y; case K::Z: return SDL_SCANCODE_Z;
+    case K::Num0: return SDL_SCANCODE_0; case K::Num1: return SDL_SCANCODE_1;
+    case K::Num2: return SDL_SCANCODE_2; case K::Num3: return SDL_SCANCODE_3;
+    case K::Num4: return SDL_SCANCODE_4; case K::Num5: return SDL_SCANCODE_5;
+    case K::Num6: return SDL_SCANCODE_6; case K::Num7: return SDL_SCANCODE_7;
+    case K::Num8: return SDL_SCANCODE_8; case K::Num9: return SDL_SCANCODE_9;
+    case K::Space: return SDL_SCANCODE_SPACE;
+    case K::Enter: return SDL_SCANCODE_RETURN;
+    case K::Escape: return SDL_SCANCODE_ESCAPE;
+    case K::Tab: return SDL_SCANCODE_TAB;
+    case K::Backspace: return SDL_SCANCODE_BACKSPACE;
+    case K::Delete: return SDL_SCANCODE_DELETE;
+    case K::Left: return SDL_SCANCODE_LEFT;
+    case K::Right: return SDL_SCANCODE_RIGHT;
+    case K::Up: return SDL_SCANCODE_UP;
+    case K::Down: return SDL_SCANCODE_DOWN;
+    case K::LeftControl: return SDL_SCANCODE_LCTRL;
+    case K::RightControl: return SDL_SCANCODE_RCTRL;
+    case K::LeftShift: return SDL_SCANCODE_LSHIFT;
+    case K::RightShift: return SDL_SCANCODE_RSHIFT;
+    case K::LeftAlt: return SDL_SCANCODE_LALT;
+    case K::RightAlt: return SDL_SCANCODE_RALT;
+    default: return SDL_SCANCODE_UNKNOWN;
+  }
+}
+} // namespace
+
+double te::now_seconds() {
+  static const Uint64 start = SDL_GetPerformanceCounter();
+  static const double freq = static_cast<double>(SDL_GetPerformanceFrequency());
+  return static_cast<double>(SDL_GetPerformanceCounter() - start) / freq;
 }
 
 WindowManager::WindowManager(std::shared_ptr<ComponentManager> cm,
                              std::shared_ptr<MouseInputSystem> mis)
     : cm(cm), mis(mis) {
-  glfwInit();
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  platform = std::make_unique<PlatformWindow>();
+
+  if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
+    std::cout << "Failed to initialize SDL: " << SDL_GetError() << std::endl;
+  }
+
+#ifdef __EMSCRIPTEN__
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#else
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#endif
   // Request an alpha channel in the framebuffer so the canvas can be composited
   // transparently over the HTML page (emscripten maps this to WebGL alpha:true).
-  glfwWindowHint(GLFW_ALPHA_BITS, 8);
+  SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
 
   int width = TESettings::WINDOW_X;
   int height = TESettings::WINDOW_Y;
 
   if (TESettings::NATIVE_RESOLUTION) {
-    GLFWmonitor *monitor = glfwGetPrimaryMonitor();
-    const GLFWvidmode *mode = glfwGetVideoMode(monitor);
-    width = mode->width;
-    height = mode->height;
-    TESettings::WINDOW_X = width;
-    TESettings::WINDOW_Y = height;
+    SDL_DisplayMode mode;
+    if (SDL_GetCurrentDisplayMode(0, &mode) == 0) {
+      width = mode.w;
+      height = mode.h;
+      TESettings::WINDOW_X = width;
+      TESettings::WINDOW_Y = height;
+    }
   }
 
+  Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE;
   if (TESettings::FULLSCREEN)
-    window = glfwCreateWindow(width, height, "Timeless", glfwGetPrimaryMonitor(), NULL);
-  else
-    window = glfwCreateWindow(width, height, "Timeless", NULL, NULL);
+    flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
-  if (window == NULL) {
-    std::cout << "Failed to create GLFW window" << std::endl;
-    glfwTerminate();
+  platform->window =
+      SDL_CreateWindow("Timeless", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                       width, height, flags);
+
+  if (platform->window == nullptr) {
+    std::cout << "Failed to create SDL window: " << SDL_GetError() << std::endl;
+    SDL_Quit();
   }
-  glfwMakeContextCurrent(window);
-  glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
-  glfwSetWindowUserPointer(window, this);
 
-  glfwSwapInterval(1);
+  platform->gl_context = SDL_GL_CreateContext(platform->window);
+  if (platform->gl_context == nullptr) {
+    std::cout << "Failed to create GL context: " << SDL_GetError() << std::endl;
+  }
+  SDL_GL_MakeCurrent(platform->window, platform->gl_context);
 
-  cursor = glfwCreateStandardCursor(GLFW_HAND_CURSOR);
-  glfwSetCursor(window, cursor);
+  SDL_GL_SetSwapInterval(1); // vsync
+
+  platform->cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+  SDL_SetCursor(platform->cursor);
 
 #ifdef __EMSCRIPTEN__
 #else
-  if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
+  if (!gladLoadGLLoader((GLADloadproc)SDL_GL_GetProcAddress)) {
     std::cout << "Failed to initialize GLAD" << std::endl;
   }
 #endif
@@ -54,10 +128,6 @@ WindowManager::WindowManager(std::shared_ptr<ComponentManager> cm,
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   std::cout << "OpenGL Initialized!" << std::endl;
-
-  glfwSetMouseButtonCallback(window, &mouse_button_callback);
-  glfwSetCursorPosCallback(window, cursor_position_callback);
-  glfwSetScrollCallback(window, &scroll_callback);
 
   glGenVertexArrays(1, &ScreenVAO);
   glGenBuffers(1, &ScreenVBO);
@@ -72,15 +142,25 @@ WindowManager::WindowManager(std::shared_ptr<ComponentManager> cm,
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
+WindowManager::~WindowManager() = default;
+
 void WindowManager::cleanup() {
   std::cout << "Destroying WindowManager..." << std::endl;
-  glfwDestroyWindow(window);
-  glfwDestroyCursor(cursor);
   glDeleteVertexArrays(1, &ScreenVAO);
   glDeleteBuffers(1, &ScreenVBO);
   for (auto fbo : framebuffers) glDeleteFramebuffers(1, &fbo);
   for (auto tex : textures) glDeleteTextures(1, &tex);
   for (auto rbo : rbos) glDeleteRenderbuffers(1, &rbo);
+
+  if (platform) {
+    if (platform->cursor) SDL_FreeCursor(platform->cursor);
+    if (platform->gl_context) SDL_GL_DeleteContext(platform->gl_context);
+    if (platform->window) SDL_DestroyWindow(platform->window);
+    platform->cursor = nullptr;
+    platform->gl_context = nullptr;
+    platform->window = nullptr;
+  }
+  SDL_Quit();
 }
 
 void WindowManager::add_framebuffer(std::shared_ptr<Shader> shader, int width, int height, bool add_screen_shader) {
@@ -184,7 +264,7 @@ void WindowManager::set_shader_time(std::shared_ptr<Shader> shader) {
 
   GLint timeLoc = glGetUniformLocation(shader->ID, "time");
   if (timeLoc != -1)
-    glUniform1f(timeLoc, glfwGetTime());
+    glUniform1f(timeLoc, static_cast<float>(te::now_seconds()));
 
   if (screen_shaders.size() > 0) {
     GLint resLoc = glGetUniformLocation(screen_shaders[0]->ID, "resolution");
@@ -198,18 +278,12 @@ void WindowManager::set_shader_mouse_position(glm::vec2 mouse_pos) {
   shader_mouse_position = mouse_pos;
 }
 
-void WindowManager::framebuffer_size_callback(GLFWwindow *window, int width, int height) {
+void WindowManager::handle_resize(int width, int height) {
   TESettings::rescale_window(width, height);
-  WindowManager *wm = static_cast<WindowManager *>(glfwGetWindowUserPointer(window));
-  if (wm == nullptr) return;
   glm::vec2 new_size(width, height);
-  if (wm->es != nullptr) {
-    wm->es->create_event<glm::vec2>(*wm->cm, "ResizeWindow", &new_size);
+  if (es != nullptr) {
+    es->create_event<glm::vec2>(*cm, "ResizeWindow", &new_size);
   }
-}
-
-void WindowManager::window_size_callback(GLFWwindow *window, int width, int height) {
-  TESettings::rescale_window(width, height);
 }
 
 void WindowManager::mouse_move_handler(MouseMoveEvent *event) {
@@ -229,79 +303,122 @@ void WindowManager::mouse_scroll_handler(MouseEvent *event) {
   mis->mouse_scroll_handler(*cm, event);
 }
 
-void WindowManager::cursor_position_callback(GLFWwindow *window, double xpos, double ypos) {
-  WindowManager *wm = static_cast<WindowManager *>(glfwGetWindowUserPointer(window));
+// --- Coordinate mapping helpers (preserve the original GLFW-callback math) ---
 
-  wm->set_shader_mouse_position(glm::vec2(xpos, ypos));
-
-  // Map cursor from window pixels to design-resolution world coordinates.
+// Cursor-move mapping: window pixels -> design-resolution world coords,
+// scaling by VIEWPORT/WINDOW then centering on the viewport.
+static glm::vec2 map_move_to_world(double xpos, double ypos) {
   double scale_x = double(TESettings::VIEWPORT_X) / TESettings::WINDOW_X;
   double scale_y = double(TESettings::VIEWPORT_Y) / TESettings::WINDOW_Y;
-  double fb_x = xpos * scale_x;
-  double fb_y = ypos * scale_y;
-
-  // Center the coordinates
-  fb_x -= TESettings::VIEWPORT_X * 0.5;
-  fb_y -= TESettings::VIEWPORT_Y * 0.5;
-
-  // Normalize and map to world coordinates
-  double xnorm = fb_x / TESettings::VIEWPORT_X;
-  double world_x = xnorm * TESettings::VIEWPORT_X;
-  double ynorm = fb_y / TESettings::VIEWPORT_Y;
-  double world_y = ynorm * TESettings::VIEWPORT_Y;
-
-  wm->mouse_move_handler(
-      new MouseMoveEvent("MouseMove", glm::vec2(world_x, world_y), glm::vec2(xpos, ypos)));
+  double fb_x = xpos * scale_x - TESettings::VIEWPORT_X * 0.5;
+  double fb_y = ypos * scale_y - TESettings::VIEWPORT_Y * 0.5;
+  double world_x = (fb_x / TESettings::VIEWPORT_X) * TESettings::VIEWPORT_X;
+  double world_y = (fb_y / TESettings::VIEWPORT_Y) * TESettings::VIEWPORT_Y;
+  return glm::vec2(world_x, world_y);
 }
 
-void WindowManager::scroll_callback(GLFWwindow *window, double xoffset, double yoffset) {
-  WindowManager *wm = static_cast<WindowManager *>(glfwGetWindowUserPointer(window));
-  wm->mouse_scroll_handler(
-      new MouseEvent("MouseScroll", wm->mouse_position, wm->raw_mouse_position, xoffset, yoffset));
+// Button mapping: window pixels -> design-resolution world coords, centering
+// on the window then scaling to the viewport.
+static glm::vec2 map_click_to_world(double xpos, double ypos) {
+  double cx = xpos - TESettings::WINDOW_X * 0.5;
+  double cy = ypos - TESettings::WINDOW_Y * 0.5;
+  double world_x = (cx / TESettings::WINDOW_X) * TESettings::VIEWPORT_X;
+  double world_y = (cy / TESettings::WINDOW_Y) * TESettings::VIEWPORT_Y;
+  return glm::vec2(world_x, world_y);
 }
 
-void WindowManager::mouse_button_callback(GLFWwindow *window, int button, int action, int mods) {
-  WindowManager *wm = static_cast<WindowManager *>(glfwGetWindowUserPointer(window));
-  double xpos, ypos;
-  glfwGetCursorPos(window, &xpos, &ypos);
+void WindowManager::poll_events() {
+  SDL_Event e;
+  while (SDL_PollEvent(&e)) {
+    switch (e.type) {
+      case SDL_QUIT:
+        quit_requested = true;
+        break;
 
-  double raw_xpos = xpos;
-  double raw_ypos = ypos;
+      case SDL_WINDOWEVENT:
+        if (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED ||
+            e.window.event == SDL_WINDOWEVENT_RESIZED) {
+          handle_resize(e.window.data1, e.window.data2);
+        } else if (e.window.event == SDL_WINDOWEVENT_CLOSE) {
+          quit_requested = true;
+        }
+        break;
 
-  // Map from window pixels to design-resolution world coordinates.
-  xpos -= TESettings::WINDOW_X * 0.5;
-  ypos -= TESettings::WINDOW_Y * 0.5;
+      case SDL_MOUSEMOTION: {
+        set_shader_mouse_position(glm::vec2(e.motion.x, e.motion.y));
+        glm::vec2 world = map_move_to_world(e.motion.x, e.motion.y);
+        mouse_move_handler(new MouseMoveEvent(
+            "MouseMove", world, glm::vec2(e.motion.x, e.motion.y)));
+        break;
+      }
 
-  double xnorm = xpos / TESettings::WINDOW_X;
-  double world_x = xnorm * TESettings::VIEWPORT_X;
-  double ynorm = ypos / TESettings::WINDOW_Y;
-  double world_y = ynorm * TESettings::VIEWPORT_Y;
+      case SDL_MOUSEWHEEL: {
+        float xoff = e.wheel.preciseX;
+        float yoff = e.wheel.preciseY;
+        mouse_scroll_handler(new MouseEvent(
+            "MouseScroll", mouse_position, raw_mouse_position, xoff, yoff));
+        break;
+      }
 
-  xpos = world_x;
-  ypos = world_y;
+      case SDL_MOUSEBUTTONDOWN:
+      case SDL_MOUSEBUTTONUP: {
+        glm::vec2 raw(e.button.x, e.button.y);
+        glm::vec2 world = map_click_to_world(e.button.x, e.button.y);
+        bool press = (e.type == SDL_MOUSEBUTTONDOWN);
+        const char *name = nullptr;
+        if (e.button.button == SDL_BUTTON_LEFT)
+          name = press ? "LeftMousePress" : "LeftMouseRelease";
+        else if (e.button.button == SDL_BUTTON_RIGHT)
+          name = press ? "RightMousePress" : "RightMouseRelease";
+        else if (e.button.button == SDL_BUTTON_MIDDLE)
+          name = press ? "MiddleMousePress" : "MiddleMouseRelease";
+        if (name) {
+          MouseEvent *ev = new MouseEvent(name, world, raw);
+          if (press)
+            mouse_click_handler(ev);
+          else
+            mouse_release_handler(ev);
+        }
+        break;
+      }
 
-  if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS) {
-    wm->mouse_click_handler(
-        new MouseEvent("LeftMousePress", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
+      default:
+        break;
+    }
   }
-  if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_RELEASE) {
-    wm->mouse_release_handler(
-        new MouseEvent("LeftMouseRelease", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
+}
+
+void WindowManager::swap_buffers() {
+  SDL_GL_SwapWindow(platform->window);
+}
+
+bool WindowManager::should_close() {
+  return quit_requested || !running;
+}
+
+bool WindowManager::is_key_pressed(te::Key key) {
+  const Uint8 *state = SDL_GetKeyboardState(nullptr);
+  SDL_Scancode sc = to_scancode(key);
+  if (sc == SDL_SCANCODE_UNKNOWN) return false;
+  return state[sc] != 0;
+}
+
+bool WindowManager::is_mouse_button_pressed(te::MouseButton button) {
+  Uint32 state = SDL_GetMouseState(nullptr, nullptr);
+  switch (button) {
+    case te::MouseButton::Left:   return (state & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
+    case te::MouseButton::Right:  return (state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
+    case te::MouseButton::Middle: return (state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
   }
-  if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS) {
-    wm->mouse_click_handler(
-        new MouseEvent("RightMousePress", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
-  }
-  if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_RELEASE) {
-    wm->mouse_release_handler(
-        new MouseEvent("RightMouseRelease", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
-  }
-  if (button == GLFW_MOUSE_BUTTON_MIDDLE && action == GLFW_PRESS) {
-    wm->mouse_click_handler(
-        new MouseEvent("MiddleMousePress", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
-  }
-  if (button == GLFW_MOUSE_BUTTON_MIDDLE && action == GLFW_RELEASE) {
-    wm->mouse_release_handler(
-        new MouseEvent("MiddleMouseRelease", glm::vec2(xpos, ypos), glm::vec2(raw_xpos, raw_ypos)));
-  }
+  return false;
+}
+
+glm::vec2 WindowManager::get_cursor_position() {
+  int x = 0, y = 0;
+  SDL_GetMouseState(&x, &y);
+  return glm::vec2(x, y);
+}
+
+void WindowManager::set_cursor_visible(bool visible) {
+  SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE);
 }

--- a/src/timeless/managers/window_manager.cpp
+++ b/src/timeless/managers/window_manager.cpp
@@ -384,10 +384,65 @@ void WindowManager::poll_events() {
         break;
       }
 
+      // Touch fingers. SDL reports normalized [0,1] coords; scale to window
+      // pixels so pan deltas share units with mouse handling. With two fingers
+      // down this drives camera pan (centroid) + pinch-zoom (spread). Single
+      // taps are still delivered as synthesized mouse clicks by SDL, so simple
+      // click interactions keep working without touching this path.
+      case SDL_FINGERDOWN:
+      case SDL_FINGERMOTION: {
+        long long id = (long long)e.tfinger.fingerId;
+        active_touches[id] = glm::vec2(e.tfinger.x * TESettings::WINDOW_X,
+                                       e.tfinger.y * TESettings::WINDOW_Y);
+        update_touch_gesture();
+        break;
+      }
+
+      case SDL_FINGERUP: {
+        active_touches.erase((long long)e.tfinger.fingerId);
+        update_touch_gesture();
+        break;
+      }
+
       default:
         break;
     }
   }
+}
+
+// Recompute the two-finger gesture baseline after any finger event. While
+// exactly two fingers are down we accumulate centroid movement (pan) and the
+// change in their separation (pinch) relative to the previous update; anything
+// other than two fingers resets the baseline so the next pinch starts clean.
+void WindowManager::update_touch_gesture() {
+  if (active_touches.size() == 2) {
+    auto it = active_touches.begin();
+    glm::vec2 a = it->second;
+    glm::vec2 b = (++it)->second;
+    glm::vec2 centroid = (a + b) * 0.5f;
+    float spread = glm::length(a - b);
+    if (two_finger_active) {
+      touch_pan_accum += centroid - gesture_centroid;
+      touch_pinch_accum += spread - gesture_spread;
+    }
+    gesture_centroid = centroid;
+    gesture_spread = spread;
+    two_finger_active = true;
+  } else {
+    two_finger_active = false;
+  }
+}
+
+glm::vec2 WindowManager::consume_touch_pan() {
+  glm::vec2 v = touch_pan_accum;
+  touch_pan_accum = glm::vec2(0.0f);
+  return v;
+}
+
+float WindowManager::consume_touch_pinch() {
+  float v = touch_pinch_accum;
+  touch_pinch_accum = 0.0f;
+  return v;
 }
 
 void WindowManager::swap_buffers() {

--- a/src/timeless/managers/window_manager.cpp
+++ b/src/timeless/managers/window_manager.cpp
@@ -256,6 +256,14 @@ void WindowManager::render_framebuffer_as_quad(size_t idx, bool clear, int tick,
   glDrawArrays(GL_TRIANGLES, 0, 6);
   glBindVertexArray(0);
   glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Restore the engine's default straight-alpha blending. The premultiplied
+  // mode above is only correct for compositing the offscreen FBOs; overlays
+  // drawn straight to the screen afterwards (text, sprites, UI) output
+  // non-premultiplied colour and would otherwise render an opaque rectangle
+  // around every glyph because GL_ONE adds the source colour even where alpha
+  // is zero.
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 void WindowManager::set_shader_time(std::shared_ptr<Shader> shader) {
@@ -478,4 +486,20 @@ glm::vec2 WindowManager::get_cursor_position() {
 
 void WindowManager::set_cursor_visible(bool visible) {
   SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE);
+}
+
+void WindowManager::set_fullscreen(bool enabled) {
+  TESettings::FULLSCREEN = enabled;
+  // The resulting SDL_WINDOWEVENT_SIZE_CHANGED is picked up in poll_events(),
+  // which rebuilds the framebuffers and rescales the viewport.
+  SDL_SetWindowFullscreen(platform->window,
+                          enabled ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+}
+
+void WindowManager::set_window_size(int width, int height) {
+  // As with fullscreen, the size change comes back as a window event that
+  // poll_events() turns into a resize.
+  SDL_SetWindowSize(platform->window, width, height);
+  SDL_SetWindowPosition(platform->window, SDL_WINDOWPOS_CENTERED,
+                        SDL_WINDOWPOS_CENTERED);
 }

--- a/src/timeless/managers/window_manager.cpp
+++ b/src/timeless/managers/window_manager.cpp
@@ -11,8 +11,8 @@ struct PlatformWindow {
 
 namespace {
 // Map engine keys to SDL scancodes (used by is_key_pressed / SDL_GetKeyboardState).
-SDL_Scancode to_scancode(te::Key key) {
-  using K = te::Key;
+SDL_Scancode to_scancode(TE::Key key) {
+  using K = TE::Key;
   switch (key) {
     case K::A: return SDL_SCANCODE_A; case K::B: return SDL_SCANCODE_B;
     case K::C: return SDL_SCANCODE_C; case K::D: return SDL_SCANCODE_D;
@@ -53,7 +53,7 @@ SDL_Scancode to_scancode(te::Key key) {
 }
 } // namespace
 
-double te::now_seconds() {
+double TE::now_seconds() {
   static const Uint64 start = SDL_GetPerformanceCounter();
   static const double freq = static_cast<double>(SDL_GetPerformanceFrequency());
   return static_cast<double>(SDL_GetPerformanceCounter() - start) / freq;
@@ -264,7 +264,7 @@ void WindowManager::set_shader_time(std::shared_ptr<Shader> shader) {
 
   GLint timeLoc = glGetUniformLocation(shader->ID, "time");
   if (timeLoc != -1)
-    glUniform1f(timeLoc, static_cast<float>(te::now_seconds()));
+    glUniform1f(timeLoc, static_cast<float>(TE::now_seconds()));
 
   if (screen_shaders.size() > 0) {
     GLint resLoc = glGetUniformLocation(screen_shaders[0]->ID, "resolution");
@@ -336,8 +336,10 @@ void WindowManager::poll_events() {
         break;
 
       case SDL_WINDOWEVENT:
-        if (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED ||
-            e.window.event == SDL_WINDOWEVENT_RESIZED) {
+        // SIZE_CHANGED covers both API- and user-driven resizes; RESIZED is a
+        // subset SDL also posts for user resizes, so handling it too would fire
+        // a duplicate "ResizeWindow" and rebuild framebuffers twice.
+        if (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
           handle_resize(e.window.data1, e.window.data2);
         } else if (e.window.event == SDL_WINDOWEVENT_CLOSE) {
           quit_requested = true;
@@ -396,19 +398,19 @@ bool WindowManager::should_close() {
   return quit_requested || !running;
 }
 
-bool WindowManager::is_key_pressed(te::Key key) {
+bool WindowManager::is_key_pressed(TE::Key key) {
   const Uint8 *state = SDL_GetKeyboardState(nullptr);
   SDL_Scancode sc = to_scancode(key);
   if (sc == SDL_SCANCODE_UNKNOWN) return false;
   return state[sc] != 0;
 }
 
-bool WindowManager::is_mouse_button_pressed(te::MouseButton button) {
+bool WindowManager::is_mouse_button_pressed(TE::MouseButton button) {
   Uint32 state = SDL_GetMouseState(nullptr, nullptr);
   switch (button) {
-    case te::MouseButton::Left:   return (state & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
-    case te::MouseButton::Right:  return (state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
-    case te::MouseButton::Middle: return (state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
+    case TE::MouseButton::Left:   return (state & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
+    case TE::MouseButton::Right:  return (state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
+    case TE::MouseButton::Middle: return (state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
   }
   return false;
 }

--- a/src/timeless/systems/keyboard_input_system.cpp
+++ b/src/timeless/systems/keyboard_input_system.cpp
@@ -16,42 +16,42 @@ glm::vec4 KeyboardInputSystem::calculate_collider(glm::vec3 position,
 }
 
 void KeyboardInputSystem::update(ComponentManager &cm, WindowManager &wm) {
-    if (wm.is_key_pressed(te::Key::Escape)) {
+    if (wm.is_key_pressed(TE::Key::Escape)) {
         keysPressed[escape] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressEscape"), entity);
     }
-    if (!wm.is_key_pressed(te::Key::Escape) && keysPressed[escape]) {
+    if (!wm.is_key_pressed(TE::Key::Escape) && keysPressed[escape]) {
         keysPressed[escape] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseEscape"), entity);
     }
-    if (wm.is_key_pressed(te::Key::Space) && !keysPressed[space]) {
+    if (wm.is_key_pressed(TE::Key::Space) && !keysPressed[space]) {
         keysPressed[space] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressSpace"), entity);
     }
-    if (!wm.is_key_pressed(te::Key::Space) && keysPressed[space]) {
+    if (!wm.is_key_pressed(TE::Key::Space) && keysPressed[space]) {
         keysPressed[space] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseSpace"), entity);
     }
-    if (wm.is_key_pressed(te::Key::Enter) && !keysPressed[enter]) {
+    if (wm.is_key_pressed(TE::Key::Enter) && !keysPressed[enter]) {
         keysPressed[enter] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressEnter"), entity);
     }
-    if (!wm.is_key_pressed(te::Key::Enter) && keysPressed[enter]) {
+    if (!wm.is_key_pressed(TE::Key::Enter) && keysPressed[enter]) {
         keysPressed[enter] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseEnter"), entity);
     }
-    if (wm.is_key_pressed(te::Key::F) && !keysPressed[f]) {
+    if (wm.is_key_pressed(TE::Key::F) && !keysPressed[f]) {
         keysPressed[f] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressF"), entity);
     }
-    if (!wm.is_key_pressed(te::Key::F) && keysPressed[f]) {
+    if (!wm.is_key_pressed(TE::Key::F) && keysPressed[f]) {
         keysPressed[f] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseF"), entity);

--- a/src/timeless/systems/keyboard_input_system.cpp
+++ b/src/timeless/systems/keyboard_input_system.cpp
@@ -1,4 +1,5 @@
 #include "timeless/systems/keyboard_input_system.hpp"
+#include "timeless/managers/window_manager.hpp"
 
 void KeyboardInputSystem::notify_listener(ComponentManager &cm,
                                           KeyboardEvent *event, Entity entity) {
@@ -14,43 +15,43 @@ glm::vec4 KeyboardInputSystem::calculate_collider(glm::vec3 position,
     return glm::vec4(x, x + width, y, y + height);
 }
 
-void KeyboardInputSystem::update(ComponentManager &cm, GLFWwindow *window) {
-    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS) {
+void KeyboardInputSystem::update(ComponentManager &cm, WindowManager &wm) {
+    if (wm.is_key_pressed(te::Key::Escape)) {
         keysPressed[escape] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressEscape"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE && keysPressed[escape]) {
+    if (!wm.is_key_pressed(te::Key::Escape) && keysPressed[escape]) {
         keysPressed[escape] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseEscape"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_PRESS && !keysPressed[space]) {
+    if (wm.is_key_pressed(te::Key::Space) && !keysPressed[space]) {
         keysPressed[space] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressSpace"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_SPACE) == GLFW_RELEASE && keysPressed[space]) {
+    if (!wm.is_key_pressed(te::Key::Space) && keysPressed[space]) {
         keysPressed[space] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseSpace"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_ENTER) == GLFW_PRESS && !keysPressed[enter]) {
+    if (wm.is_key_pressed(te::Key::Enter) && !keysPressed[enter]) {
         keysPressed[enter] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressEnter"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_ENTER) == GLFW_RELEASE && keysPressed[enter]) {
+    if (!wm.is_key_pressed(te::Key::Enter) && keysPressed[enter]) {
         keysPressed[enter] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseEnter"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_F) == GLFW_PRESS && !keysPressed[f]) {
+    if (wm.is_key_pressed(te::Key::F) && !keysPressed[f]) {
         keysPressed[f] = true;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("PressF"), entity);
     }
-    if (glfwGetKey(window, GLFW_KEY_F) == GLFW_RELEASE && keysPressed[f]) {
+    if (!wm.is_key_pressed(te::Key::F) && keysPressed[f]) {
         keysPressed[f] = false;
         for (auto &entity : registered_entities)
             notify_listener(cm, new KeyboardEvent("ReleaseF"), entity);

--- a/src/timeless/systems/mouse_input_system.cpp
+++ b/src/timeless/systems/mouse_input_system.cpp
@@ -86,10 +86,3 @@ void MouseInputSystem::mouse_scroll_handler(ComponentManager &cm,
     }
     delete event;
 }
-
-void MouseInputSystem::scroll_callback(GLFWwindow *window, double xoffset,
-                                        double yoffset) {
-    // ViewportSettings::SCR_VIEWPORT_X += (ViewportSettings::SCR_VIEWPORT_X *
-    // yoffset) * 0.5f; ViewportSettings::SCR_VIEWPORT_Y +=
-    // (ViewportSettings::SCR_VIEWPORT_Y * yoffset) * 0.5f;
-}

--- a/src/timeless/systems/movement_system.cpp
+++ b/src/timeless/systems/movement_system.cpp
@@ -1,10 +1,13 @@
 #include "timeless/systems/movement_system.hpp"
 #include "timeless/managers/window_manager.hpp"
+#include <algorithm>
+#include <cmath>
 
 MovementSystem::MovementSystem()
     : x_bounds(glm::vec2(-TESettings::SCREEN_X, TESettings::SCREEN_X)),
       y_bounds(glm::vec2(-TESettings::SCREEN_Y, TESettings::SCREEN_Y)),
-      walk_speed(1.0f), camera_speed(15.0f) {}
+      walk_speed(1.0f), zoom_target(TESettings::ZOOM),
+      last_applied_zoom(TESettings::ZOOM) {}
 
 void MovementSystem::register_camera(Entity c) { camera = c; }
 
@@ -34,12 +37,6 @@ void MovementSystem::move_right(ComponentManager &cm) {
             }
         }
     }
-    auto main_camera = cm.get_component<Camera>(camera);
-    if (main_camera != nullptr)
-        main_camera->set_position(glm::vec3(
-            main_camera->get_position().x + camera_speed,
-            main_camera->get_position().y,
-            main_camera->get_position().z));
 }
 
 void MovementSystem::move_left(ComponentManager &cm) {
@@ -61,12 +58,6 @@ void MovementSystem::move_left(ComponentManager &cm) {
             }
         }
     }
-    auto main_camera = cm.get_component<Camera>(camera);
-    if (main_camera != nullptr)
-        main_camera->set_position(glm::vec3(
-            main_camera->get_position().x - camera_speed,
-            main_camera->get_position().y,
-            main_camera->get_position().z));
 }
 
 void MovementSystem::move_down(ComponentManager &cm) {
@@ -87,12 +78,6 @@ void MovementSystem::move_down(ComponentManager &cm) {
             }
         }
     }
-    auto main_camera = cm.get_component<Camera>(camera);
-    if (main_camera != nullptr)
-        main_camera->set_position(glm::vec3(
-            main_camera->get_position().x,
-            main_camera->get_position().y + camera_speed,
-            main_camera->get_position().z));
 }
 
 void MovementSystem::move_up(ComponentManager &cm) {
@@ -113,23 +98,43 @@ void MovementSystem::move_up(ComponentManager &cm) {
             }
         }
     }
-    auto main_camera = cm.get_component<Camera>(camera);
-    if (main_camera != nullptr)
-        main_camera->set_position(glm::vec3(
-            main_camera->get_position().x,
-            main_camera->get_position().y - camera_speed,
-            main_camera->get_position().z));
 }
 
-void MovementSystem::update(ComponentManager &cm, WindowManager &wm) {
-    if (wm.is_key_pressed(TE::Key::D)) { move_right(cm); keysPressed[d] = true; }
-    if (wm.is_key_pressed(TE::Key::A)) { move_left(cm);  keysPressed[a] = true; }
-    if (wm.is_key_pressed(TE::Key::W)) { move_up(cm);    keysPressed[w] = true; }
-    if (wm.is_key_pressed(TE::Key::S)) { move_down(cm);  keysPressed[s] = true; }
-    if (wm.is_key_pressed(TE::Key::Up))    { move_up(cm);    keysPressed[up]    = true; }
-    if (wm.is_key_pressed(TE::Key::Down))  { move_down(cm);  keysPressed[down]  = true; }
-    if (wm.is_key_pressed(TE::Key::Left))  { move_left(cm);  keysPressed[left]  = true; }
-    if (wm.is_key_pressed(TE::Key::Right)) { move_right(cm); keysPressed[right] = true; }
+void MovementSystem::zoom_by(float notches) {
+    // Multiplicative rather than additive: a notch is always the same relative
+    // change, so zooming feels identical whether you're at 0.2 or 4.0.
+    // Larger ZOOM = wider ortho extents = further out, hence the negated exponent.
+    zoom_target = std::clamp(zoom_target * std::pow(zoom_step, -notches),
+                             zoom_limits[0], zoom_limits[1]);
+}
+
+void MovementSystem::zoom_to(float zoom) {
+    zoom_target = std::clamp(zoom, zoom_limits[0], zoom_limits[1]);
+}
+
+void MovementSystem::set_zoom(float zoom) {
+    zoom_target       = std::clamp(zoom, zoom_limits[0], zoom_limits[1]);
+    TESettings::ZOOM  = zoom_target;
+    last_applied_zoom = zoom_target;
+}
+
+void MovementSystem::update(ComponentManager &cm, WindowManager &wm,
+                            float delta_time) {
+    // Guard against pauses/breakpoints producing a huge step.
+    float dt = std::clamp(delta_time, 0.0f, 0.1f);
+
+    // -- gather pan input -------------------------------------------------
+    // +x = right, +y = down in camera terms (matches the old move_* directions).
+    glm::vec2 dir(0.0f);
+
+    if (wm.is_key_pressed(TE::Key::D)) { move_right(cm); dir.x += 1.0f; keysPressed[d] = true; }
+    if (wm.is_key_pressed(TE::Key::A)) { move_left(cm);  dir.x -= 1.0f; keysPressed[a] = true; }
+    if (wm.is_key_pressed(TE::Key::W)) { move_up(cm);    dir.y -= 1.0f; keysPressed[w] = true; }
+    if (wm.is_key_pressed(TE::Key::S)) { move_down(cm);  dir.y += 1.0f; keysPressed[s] = true; }
+    if (wm.is_key_pressed(TE::Key::Up))    { move_up(cm);    dir.y -= 1.0f; keysPressed[up]    = true; }
+    if (wm.is_key_pressed(TE::Key::Down))  { move_down(cm);  dir.y += 1.0f; keysPressed[down]  = true; }
+    if (wm.is_key_pressed(TE::Key::Left))  { move_left(cm);  dir.x -= 1.0f; keysPressed[left]  = true; }
+    if (wm.is_key_pressed(TE::Key::Right)) { move_right(cm); dir.x += 1.0f; keysPressed[right] = true; }
     if (wm.is_key_pressed(TE::Key::Escape)) keysPressed[escape] = true;
 
     if (!wm.is_key_pressed(TE::Key::Escape) && keysPressed[escape]) keysPressed[escape] = false;
@@ -142,15 +147,60 @@ void MovementSystem::update(ComponentManager &cm, WindowManager &wm) {
     if (!wm.is_key_pressed(TE::Key::Left)   && keysPressed[left])   keysPressed[left]   = false;
     if (!wm.is_key_pressed(TE::Key::Right)  && keysPressed[right])  keysPressed[right]  = false;
 
-    // Edge scrolling
+    // Edge scrolling, ramped by how deep into the margin the cursor is instead
+    // of switching on at full speed the moment it crosses the threshold.
     {
         glm::vec2 cursor = wm.get_cursor_position();
-        int win_w = TESettings::WINDOW_X;
-        int win_h = TESettings::WINDOW_Y;
-        constexpr int edge_margin = 20;
-        if (cursor.x >= win_w - edge_margin) move_right(cm);
-        if (cursor.x <= edge_margin)         move_left(cm);
-        if (cursor.y <= edge_margin)         move_up(cm);
-        if (cursor.y >= win_h - edge_margin) move_down(cm);
+        float win_w = static_cast<float>(TESettings::WINDOW_X);
+        float win_h = static_cast<float>(TESettings::WINDOW_Y);
+        bool inside = cursor.x >= 0.0f && cursor.x <= win_w &&
+                      cursor.y >= 0.0f && cursor.y <= win_h;
+        if (inside && edge_margin > 0.0f) {
+            auto ramp = [this](float distance_into_margin) {
+                return std::clamp(distance_into_margin / edge_margin, 0.0f, 1.0f);
+            };
+            dir.x += ramp(cursor.x - (win_w - edge_margin));
+            dir.x -= ramp(edge_margin - cursor.x);
+            dir.y -= ramp(edge_margin - cursor.y);
+            dir.y += ramp(cursor.y - (win_h - edge_margin));
+        }
     }
+
+    // Clamp instead of normalize: keeps diagonals from being ~1.4x faster while
+    // still letting a partially-ramped edge scroll move at partial speed.
+    float dir_len = glm::length(dir);
+    if (dir_len > 1.0f) dir /= dir_len;
+
+    // -- pan ---------------------------------------------------------------
+    auto main_camera = cm.get_component<Camera>(camera);
+    if (main_camera != nullptr) {
+        // Scale by zoom so the world slides past at a constant *screen* rate:
+        // slow when zoomed in, fast when zoomed out.
+        float zoom_scale = std::pow(std::max(TESettings::ZOOM, 0.0001f),
+                                    zoom_pan_exponent);
+        glm::vec2 target_velocity = dir * camera_speed * zoom_scale;
+
+        // Frame-rate independent exponential approach: the fraction we close
+        // per frame depends on dt, so the feel is identical at 30 or 144 fps.
+        float t      = 1.0f - std::exp(-pan_smoothing * dt);
+        pan_velocity = glm::mix(pan_velocity, target_velocity, t);
+        if (glm::length(pan_velocity) < 0.01f) pan_velocity = glm::vec2(0.0f);
+
+        glm::vec3 pos = main_camera->get_position();
+        main_camera->set_position(glm::vec3(pos.x + pan_velocity.x * dt,
+                                            pos.y + pan_velocity.y * dt,
+                                            pos.z));
+    }
+
+    // -- zoom --------------------------------------------------------------
+    // Anything that writes TESettings::ZOOM directly (cutscenes, focus helpers)
+    // wins: adopt it as the new target rather than fighting it.
+    if (std::abs(TESettings::ZOOM - last_applied_zoom) > 1e-4f)
+        zoom_target = TESettings::ZOOM;
+
+    float zt = 1.0f - std::exp(-zoom_smoothing * dt);
+    TESettings::ZOOM = glm::mix(TESettings::ZOOM, zoom_target, zt);
+    if (std::abs(TESettings::ZOOM - zoom_target) < 1e-4f)
+        TESettings::ZOOM = zoom_target;
+    last_applied_zoom = TESettings::ZOOM;
 }

--- a/src/timeless/systems/movement_system.cpp
+++ b/src/timeless/systems/movement_system.cpp
@@ -122,25 +122,25 @@ void MovementSystem::move_up(ComponentManager &cm) {
 }
 
 void MovementSystem::update(ComponentManager &cm, WindowManager &wm) {
-    if (wm.is_key_pressed(te::Key::D)) { move_right(cm); keysPressed[d] = true; }
-    if (wm.is_key_pressed(te::Key::A)) { move_left(cm);  keysPressed[a] = true; }
-    if (wm.is_key_pressed(te::Key::W)) { move_up(cm);    keysPressed[w] = true; }
-    if (wm.is_key_pressed(te::Key::S)) { move_down(cm);  keysPressed[s] = true; }
-    if (wm.is_key_pressed(te::Key::Up))    { move_up(cm);    keysPressed[up]    = true; }
-    if (wm.is_key_pressed(te::Key::Down))  { move_down(cm);  keysPressed[down]  = true; }
-    if (wm.is_key_pressed(te::Key::Left))  { move_left(cm);  keysPressed[left]  = true; }
-    if (wm.is_key_pressed(te::Key::Right)) { move_right(cm); keysPressed[right] = true; }
-    if (wm.is_key_pressed(te::Key::Escape)) keysPressed[escape] = true;
+    if (wm.is_key_pressed(TE::Key::D)) { move_right(cm); keysPressed[d] = true; }
+    if (wm.is_key_pressed(TE::Key::A)) { move_left(cm);  keysPressed[a] = true; }
+    if (wm.is_key_pressed(TE::Key::W)) { move_up(cm);    keysPressed[w] = true; }
+    if (wm.is_key_pressed(TE::Key::S)) { move_down(cm);  keysPressed[s] = true; }
+    if (wm.is_key_pressed(TE::Key::Up))    { move_up(cm);    keysPressed[up]    = true; }
+    if (wm.is_key_pressed(TE::Key::Down))  { move_down(cm);  keysPressed[down]  = true; }
+    if (wm.is_key_pressed(TE::Key::Left))  { move_left(cm);  keysPressed[left]  = true; }
+    if (wm.is_key_pressed(TE::Key::Right)) { move_right(cm); keysPressed[right] = true; }
+    if (wm.is_key_pressed(TE::Key::Escape)) keysPressed[escape] = true;
 
-    if (!wm.is_key_pressed(te::Key::Escape) && keysPressed[escape]) keysPressed[escape] = false;
-    if (!wm.is_key_pressed(te::Key::A)      && keysPressed[a])      keysPressed[a]      = false;
-    if (!wm.is_key_pressed(te::Key::W)      && keysPressed[w])      keysPressed[w]      = false;
-    if (!wm.is_key_pressed(te::Key::S)      && keysPressed[s])      keysPressed[s]      = false;
-    if (!wm.is_key_pressed(te::Key::D)      && keysPressed[d])      keysPressed[d]      = false;
-    if (!wm.is_key_pressed(te::Key::Up)     && keysPressed[up])     keysPressed[up]     = false;
-    if (!wm.is_key_pressed(te::Key::Down)   && keysPressed[down])   keysPressed[down]   = false;
-    if (!wm.is_key_pressed(te::Key::Left)   && keysPressed[left])   keysPressed[left]   = false;
-    if (!wm.is_key_pressed(te::Key::Right)  && keysPressed[right])  keysPressed[right]  = false;
+    if (!wm.is_key_pressed(TE::Key::Escape) && keysPressed[escape]) keysPressed[escape] = false;
+    if (!wm.is_key_pressed(TE::Key::A)      && keysPressed[a])      keysPressed[a]      = false;
+    if (!wm.is_key_pressed(TE::Key::W)      && keysPressed[w])      keysPressed[w]      = false;
+    if (!wm.is_key_pressed(TE::Key::S)      && keysPressed[s])      keysPressed[s]      = false;
+    if (!wm.is_key_pressed(TE::Key::D)      && keysPressed[d])      keysPressed[d]      = false;
+    if (!wm.is_key_pressed(TE::Key::Up)     && keysPressed[up])     keysPressed[up]     = false;
+    if (!wm.is_key_pressed(TE::Key::Down)   && keysPressed[down])   keysPressed[down]   = false;
+    if (!wm.is_key_pressed(TE::Key::Left)   && keysPressed[left])   keysPressed[left]   = false;
+    if (!wm.is_key_pressed(TE::Key::Right)  && keysPressed[right])  keysPressed[right]  = false;
 
     // Edge scrolling
     {

--- a/src/timeless/systems/movement_system.cpp
+++ b/src/timeless/systems/movement_system.cpp
@@ -1,4 +1,5 @@
 #include "timeless/systems/movement_system.hpp"
+#include "timeless/managers/window_manager.hpp"
 
 MovementSystem::MovementSystem()
     : x_bounds(glm::vec2(-TESettings::SCREEN_X, TESettings::SCREEN_X)),
@@ -120,37 +121,36 @@ void MovementSystem::move_up(ComponentManager &cm) {
             main_camera->get_position().z));
 }
 
-void MovementSystem::update(ComponentManager &cm, GLFWwindow *window) {
-    if (glfwGetKey(window, GLFW_KEY_D) == GLFW_PRESS) { move_right(cm); keysPressed[d] = true; }
-    if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS) { move_left(cm);  keysPressed[a] = true; }
-    if (glfwGetKey(window, GLFW_KEY_W) == GLFW_PRESS) { move_up(cm);    keysPressed[w] = true; }
-    if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS) { move_down(cm);  keysPressed[s] = true; }
-    if (glfwGetKey(window, GLFW_KEY_UP)    == GLFW_PRESS) { move_up(cm);    keysPressed[up]    = true; }
-    if (glfwGetKey(window, GLFW_KEY_DOWN)  == GLFW_PRESS) { move_down(cm);  keysPressed[down]  = true; }
-    if (glfwGetKey(window, GLFW_KEY_LEFT)  == GLFW_PRESS) { move_left(cm);  keysPressed[left]  = true; }
-    if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS) { move_right(cm); keysPressed[right] = true; }
-    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS) keysPressed[escape] = true;
+void MovementSystem::update(ComponentManager &cm, WindowManager &wm) {
+    if (wm.is_key_pressed(te::Key::D)) { move_right(cm); keysPressed[d] = true; }
+    if (wm.is_key_pressed(te::Key::A)) { move_left(cm);  keysPressed[a] = true; }
+    if (wm.is_key_pressed(te::Key::W)) { move_up(cm);    keysPressed[w] = true; }
+    if (wm.is_key_pressed(te::Key::S)) { move_down(cm);  keysPressed[s] = true; }
+    if (wm.is_key_pressed(te::Key::Up))    { move_up(cm);    keysPressed[up]    = true; }
+    if (wm.is_key_pressed(te::Key::Down))  { move_down(cm);  keysPressed[down]  = true; }
+    if (wm.is_key_pressed(te::Key::Left))  { move_left(cm);  keysPressed[left]  = true; }
+    if (wm.is_key_pressed(te::Key::Right)) { move_right(cm); keysPressed[right] = true; }
+    if (wm.is_key_pressed(te::Key::Escape)) keysPressed[escape] = true;
 
-    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_RELEASE && keysPressed[escape]) keysPressed[escape] = false;
-    if (glfwGetKey(window, GLFW_KEY_A)      == GLFW_RELEASE && keysPressed[a])      keysPressed[a]      = false;
-    if (glfwGetKey(window, GLFW_KEY_W)      == GLFW_RELEASE && keysPressed[w])      keysPressed[w]      = false;
-    if (glfwGetKey(window, GLFW_KEY_S)      == GLFW_RELEASE && keysPressed[s])      keysPressed[s]      = false;
-    if (glfwGetKey(window, GLFW_KEY_D)      == GLFW_RELEASE && keysPressed[d])      keysPressed[d]      = false;
-    if (glfwGetKey(window, GLFW_KEY_UP)     == GLFW_RELEASE && keysPressed[up])     keysPressed[up]     = false;
-    if (glfwGetKey(window, GLFW_KEY_DOWN)   == GLFW_RELEASE && keysPressed[down])   keysPressed[down]   = false;
-    if (glfwGetKey(window, GLFW_KEY_LEFT)   == GLFW_RELEASE && keysPressed[left])   keysPressed[left]   = false;
-    if (glfwGetKey(window, GLFW_KEY_RIGHT)  == GLFW_RELEASE && keysPressed[right])  keysPressed[right]  = false;
+    if (!wm.is_key_pressed(te::Key::Escape) && keysPressed[escape]) keysPressed[escape] = false;
+    if (!wm.is_key_pressed(te::Key::A)      && keysPressed[a])      keysPressed[a]      = false;
+    if (!wm.is_key_pressed(te::Key::W)      && keysPressed[w])      keysPressed[w]      = false;
+    if (!wm.is_key_pressed(te::Key::S)      && keysPressed[s])      keysPressed[s]      = false;
+    if (!wm.is_key_pressed(te::Key::D)      && keysPressed[d])      keysPressed[d]      = false;
+    if (!wm.is_key_pressed(te::Key::Up)     && keysPressed[up])     keysPressed[up]     = false;
+    if (!wm.is_key_pressed(te::Key::Down)   && keysPressed[down])   keysPressed[down]   = false;
+    if (!wm.is_key_pressed(te::Key::Left)   && keysPressed[left])   keysPressed[left]   = false;
+    if (!wm.is_key_pressed(te::Key::Right)  && keysPressed[right])  keysPressed[right]  = false;
 
     // Edge scrolling
     {
-        double xpos, ypos;
-        glfwGetCursorPos(window, &xpos, &ypos);
-        int win_w, win_h;
-        glfwGetWindowSize(window, &win_w, &win_h);
+        glm::vec2 cursor = wm.get_cursor_position();
+        int win_w = TESettings::WINDOW_X;
+        int win_h = TESettings::WINDOW_Y;
         constexpr int edge_margin = 20;
-        if (xpos >= win_w - edge_margin) move_right(cm);
-        if (xpos <= edge_margin)         move_left(cm);
-        if (ypos <= edge_margin)         move_up(cm);
-        if (ypos >= win_h - edge_margin) move_down(cm);
+        if (cursor.x >= win_w - edge_margin) move_right(cm);
+        if (cursor.x <= edge_margin)         move_left(cm);
+        if (cursor.y <= edge_margin)         move_up(cm);
+        if (cursor.y >= win_h - edge_margin) move_down(cm);
     }
 }

--- a/src/timeless/systems/rendering_system.cpp
+++ b/src/timeless/systems/rendering_system.cpp
@@ -1,4 +1,5 @@
 #include "timeless/systems/rendering_system.hpp"
+#include "timeless/input.hpp"
 #include <cmath>
 
 // ---------------------------------------------------------------------------
@@ -392,7 +393,7 @@ void RenderingSystem::render(ComponentManager &cm, int x, int y, float zoom,
 
   // Cache per-frame values once — avoids redundant matrix computations and
   // system calls inside the per-entity loop.
-  const float time = (float)glfwGetTime();
+  const float time = (float)te::now_seconds();
   glm::mat4 view{}, projection{};
   glm::vec3 cam_pos{};
   Frustum frustum{};
@@ -751,7 +752,7 @@ void RenderingSystem::instanced_render(ComponentManager &cm, int x, int y,
   glUniform2fv(shader->get_uniform("spriteSheetSize"), 1,
                glm::value_ptr(glm::vec2(texture->width, texture->height)));
 
-  const float time = (float)glfwGetTime();
+  const float time = (float)te::now_seconds();
   glm::mat4 view = cam->get_view_matrix();
   glm::mat4 projection = cam->get_projection_matrix(x, y, zoom);
   glUniformMatrix4fv(shader->get_uniform("projection"), 1,
@@ -868,7 +869,7 @@ void RenderingSystem::instanced_model_render(ComponentManager &cm, int x, int y,
   if (cam != nullptr)
     pre_filter_lights(cam);
 
-  const float time = (float)glfwGetTime();
+  const float time = (float)te::now_seconds();
   glm::mat4 view{}, projection{};
   glm::vec3 cam_pos{};
   if (cam != nullptr) {

--- a/src/timeless/systems/rendering_system.cpp
+++ b/src/timeless/systems/rendering_system.cpp
@@ -393,7 +393,7 @@ void RenderingSystem::render(ComponentManager &cm, int x, int y, float zoom,
 
   // Cache per-frame values once — avoids redundant matrix computations and
   // system calls inside the per-entity loop.
-  const float time = (float)te::now_seconds();
+  const float time = (float)TE::now_seconds();
   glm::mat4 view{}, projection{};
   glm::vec3 cam_pos{};
   Frustum frustum{};
@@ -752,7 +752,7 @@ void RenderingSystem::instanced_render(ComponentManager &cm, int x, int y,
   glUniform2fv(shader->get_uniform("spriteSheetSize"), 1,
                glm::value_ptr(glm::vec2(texture->width, texture->height)));
 
-  const float time = (float)te::now_seconds();
+  const float time = (float)TE::now_seconds();
   glm::mat4 view = cam->get_view_matrix();
   glm::mat4 projection = cam->get_projection_matrix(x, y, zoom);
   glUniformMatrix4fv(shader->get_uniform("projection"), 1,
@@ -869,7 +869,7 @@ void RenderingSystem::instanced_model_render(ComponentManager &cm, int x, int y,
   if (cam != nullptr)
     pre_filter_lights(cam);
 
-  const float time = (float)te::now_seconds();
+  const float time = (float)TE::now_seconds();
   glm::mat4 view{}, projection{};
   glm::vec3 cam_pos{};
   if (cam != nullptr) {

--- a/src/timeless/systems/rendering_system.cpp
+++ b/src/timeless/systems/rendering_system.cpp
@@ -1,6 +1,8 @@
 #include "timeless/systems/rendering_system.hpp"
+#include "timeless/components/shader_uniforms.hpp"
 #include "timeless/input.hpp"
 #include <cmath>
+#include <glm/gtc/type_ptr.hpp>
 
 // ---------------------------------------------------------------------------
 // Shadow map setup
@@ -592,45 +594,20 @@ void RenderingSystem::render(ComponentManager &cm, int x, int y, float zoom,
           if (texture != nullptr)
             texture->render();
 
-          // Per-entity sun-burn uniforms — the fragment shader reddens only the
-          // sunlit fragments. Set 0 for entities without a burn so the previous
-          // entity's value doesn't leak (get_uniform is a no-op == -1 for
-          // shaders without these uniforms).
-          auto burnIt = entity_burn.find(entity);
-          float burnAmt = (burnIt != entity_burn.end()) ? burnIt->second.w : 0.0f;
-          glm::vec3 burnCol = (burnIt != entity_burn.end())
-                                  ? glm::vec3(burnIt->second)
-                                  : glm::vec3(1.0f);
-          glUniform1f(shader->get_uniform("burnAmount"), burnAmt);
-          glUniform3fv(shader->get_uniform("burnColor"), 1,
-                       glm::value_ptr(burnCol));
-          auto tanIt = entity_tan.find(entity);
-          float tanAmt = (tanIt != entity_tan.end()) ? tanIt->second.w : 0.0f;
-          glm::vec3 tanCol = (tanIt != entity_tan.end())
-                                 ? glm::vec3(tanIt->second)
-                                 : glm::vec3(1.0f);
-          glUniform1f(shader->get_uniform("tanAmount"), tanAmt);
-          glUniform3fv(shader->get_uniform("tanColor"), 1,
-                       glm::value_ptr(tanCol));
-          auto sheenIt = entity_sheen.find(entity);
-          glUniform1f(shader->get_uniform("sheen"),
-                      sheenIt != entity_sheen.end() ? sheenIt->second : 0.0f);
-          // Per-entity pants tint (white = unchanged); the model's per-mesh
-          // isPants uniform decides which mesh it actually affects.
-          auto pantsIt = entity_pants.find(entity);
-          glm::vec3 pantsCol = (pantsIt != entity_pants.end()) ? pantsIt->second
-                                                               : glm::vec3(1.0f);
-          glUniform3fv(shader->get_uniform("pantsColor"), 1,
-                       glm::value_ptr(pantsCol));
-          // Per-entity translucency: output as fragment alpha, and for a
-          // translucent entity drop depth writes so it doesn't occlude geometry
-          // behind it (depth test stays on, so it's still hidden by nearer
-          // opaque geometry). Restore the depth mask afterwards.
-          auto alphaIt = entity_alpha.find(entity);
-          float modelAlpha =
-              (alphaIt != entity_alpha.end()) ? alphaIt->second : 1.0f;
-          glUniform1f(shader->get_uniform("modelAlpha"), modelAlpha);
-          bool translucent = modelAlpha < 0.999f;
+          // Per-entity shader uniform overrides (game-specific tints,
+          // translucency, ...) live on an optional ShaderUniforms component, so
+          // the engine stays ignorant of what they mean — it just uploads the
+          // name/value pairs. For a translucent entity drop depth writes so it
+          // doesn't occlude geometry behind it (depth test stays on, so it's
+          // still hidden by nearer opaque geometry). Restore the mask afterwards.
+          bool translucent = false;
+          if (auto su = cm.get_component<ShaderUniforms>(entity)) {
+            for (auto &[name, v] : su->floats)
+              glUniform1f(shader->get_uniform(name), v);
+            for (auto &[name, v] : su->vec3s)
+              glUniform3fv(shader->get_uniform(name), 1, glm::value_ptr(v));
+            translucent = su->translucent;
+          }
           if (translucent)
             glDepthMask(GL_FALSE);
           model->render(transform->model, delta_time,

--- a/src/timeless/systems/sound_system.cpp
+++ b/src/timeless/systems/sound_system.cpp
@@ -28,7 +28,7 @@ void SoundSystem::init() {
     }
 }
 
-void SoundSystem::load_bank_files(std::string master_bank_filename,
+bool SoundSystem::load_bank_files(std::string master_bank_filename,
                                    std::string strings_bank_filename) {
     if (masterBank == NULL) {
         FMOD_RESULT result = fmodSystem->loadBankFile(
@@ -36,7 +36,7 @@ void SoundSystem::load_bank_files(std::string master_bank_filename,
             &masterBank);
         if (result != FMOD_OK) {
             printf("FMOD error! (%d) %s\n", result, FMOD_ErrorString(result));
-            exit(-1);
+            return false;
         }
     }
     if (stringsBank == NULL) {
@@ -45,10 +45,11 @@ void SoundSystem::load_bank_files(std::string master_bank_filename,
             &stringsBank);
         if (result != FMOD_OK) {
             printf("FMOD error! (%d) %s\n", result, FMOD_ErrorString(result));
-            exit(-1);
+            return false;
         }
     }
     std::cout << "[TIMELESS] Sound banks loaded!" << std::endl;
+    return true;
 }
 
 void SoundSystem::update(ComponentManager &cm) {

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,61 @@
+# timeless/web — WebAssembly (Emscripten) tooling
+
+Reusable shell + build scripts for shipping a timeless game to the web
+(itch.io). Run the scripts **from your game's repo root** — they operate on
+`./` (CMake source) and `./build/wasm` (build dir) and auto-detect the
+Emscripten target's name.
+
+```bash
+# from <game-repo>/
+timeless/web/build-wasm.sh           # configure + build + package (threaded)
+timeless/web/build-wasm.sh --single  # single-threaded fallback
+timeless/web/build-wasm.sh --clean   # wipe build/wasm first (switching modes)
+timeless/web/serve-wasm.py           # local test server (COOP/COEP headers)
+timeless/web/package-wasm.sh         # (re)package build/wasm/<exe>.zip only
+```
+
+Output is `build/wasm/<exe-lowercased>.zip` containing `index.html`
+(renamed from `<Exe>.html`), `<Exe>.js`, `<Exe>.wasm` — upload that to itch.
+
+## shell.html
+
+`shell.html` is wired in automatically: timeless adds `--shell-file
+.../web/shell.html` as a PUBLIC link option for the Emscripten build, so any
+target linking timeless inherits it. To use your own branded shell, point
+`--shell-file` at your copy (the last `--shell-file` wins). It provides:
+
+- **Letterboxed canvas scaling** for timeless's fixed-resolution rendering, incl.
+  scaling *up* to fill fullscreen.
+- **Native fullscreen** (the ⛶ button) that doesn't fight the scaling.
+- **Audio start-gate** (see below).
+
+## Audio start-gate contract
+
+Browsers won't play audio until a user gesture *in the game's own document*
+(itch's "Run game" button is in the parent page and doesn't count), and FMOD's
+`AudioContext.resume()` must run synchronously inside that gesture. The shell
+shows a "Click to start" overlay, waits until FMOD's context exists, then on the
+click resumes it in-handler and sets `window._timelessStarted = true`.
+
+**Your game's main loop must freeze the simulation until that flag is set**, so
+the intro/audio start together. Reference implementation (Beach `app.hpp`):
+
+```cpp
+bool run_sim = true;
+#ifdef __EMSCRIPTEN__
+  static bool started = false;
+  if (!started)
+    started = emscripten_run_script_int("(window._timelessStarted?1:0)") != 0;
+  run_sim = started;
+#endif
+if (run_sim) { /* update scene / cutscene / animation / sound */ }
+// render every frame regardless
+```
+
+## Threaded build & itch.io
+
+The default build is threaded (`-DEMSCRIPTEN_PTHREADS=ON`) so FMOD mixes on a
+worker thread and main-thread stalls don't drop audio. SharedArrayBuffer
+requires cross-origin isolation: **enable itch.io's "SharedArrayBuffer
+support"**, and locally use `serve-wasm.py` (plain `http.server` sends no
+COOP/COEP headers, so SAB is undefined and the threaded build won't start).

--- a/web/build-wasm.sh
+++ b/web/build-wasm.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Configure, build, and package a timeless game's WASM build for itch.io in one
+# shot. Run from the GAME's repo root (it uses ./ as the CMake source and
+# ./build/wasm as the build dir). Output: build/wasm/<exe-lowercased>.zip
+#
+# Defaults to the THREADED build (EMSCRIPTEN_PTHREADS=ON) so FMOD mixes on its
+# own worker thread and a main-thread stall doesn't drop audio. The threaded
+# build needs cross-origin isolation: enable itch.io's "SharedArrayBuffer
+# support", and test locally with serve-wasm.py (NOT plain http.server).
+#
+# Usage (from the game repo root):
+#   /path/to/timeless/web/build-wasm.sh            # threaded (default)
+#   /path/to/timeless/web/build-wasm.sh --single   # single-threaded fallback
+#   /path/to/timeless/web/build-wasm.sh --clean    # wipe build/wasm first (use
+#                                                  # when switching threading mode)
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$PWD"
+BUILD="$ROOT/build/wasm"
+PTHREADS=ON
+CLEAN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --single)   PTHREADS=OFF ;;
+    --threaded) PTHREADS=ON ;;
+    --clean)    CLEAN=1 ;;
+    *) echo "unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+command -v emcmake >/dev/null 2>&1 || {
+  echo "error: emcmake not found — source the emsdk first (e.g. 'source \$EMSDK/emsdk_env.sh')" >&2
+  exit 1
+}
+[ -f "$ROOT/CMakeLists.txt" ] || {
+  echo "error: no CMakeLists.txt in $ROOT — run this from the game's repo root" >&2
+  exit 1
+}
+
+if [ "$CLEAN" = 1 ]; then
+  echo "==> Cleaning $BUILD"
+  rm -rf "$BUILD"
+fi
+mkdir -p "$BUILD"
+
+echo "==> Configuring (EMSCRIPTEN_PTHREADS=$PTHREADS)"
+emcmake cmake "$ROOT" -B "$BUILD" -DEMSCRIPTEN=ON -DEMSCRIPTEN_PTHREADS="$PTHREADS"
+
+echo "==> Building"
+# Force the link step to pick up shell.html changes (not tracked as a CMake dep).
+rm -f "$BUILD"/*.html
+emmake make -C "$BUILD" -j"$(nproc)"
+
+echo "==> Packaging"
+"$SCRIPT_DIR/package-wasm.sh"
+
+if [ "$PTHREADS" = ON ]; then
+  echo
+  echo "Threaded build — remember to enable itch.io's \"SharedArrayBuffer support\"."
+  echo "Test locally with: $SCRIPT_DIR/serve-wasm.py"
+fi

--- a/web/package-wasm.sh
+++ b/web/package-wasm.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Package a timeless game's WASM build for itch.io.
+# Run from the GAME's repo root (it operates on ./build/wasm). itch.io requires
+# the entry page to be named index.html and serves the zip's contents directly,
+# so we rename <Exe>.html -> index.html and bundle it with the JS loader and the
+# .wasm module. Output: build/wasm/<exe-lowercased>.zip
+#
+# Usage:  cd <game-repo> && /path/to/timeless/web/package-wasm.sh [ExeName]
+# ExeName is auto-detected from the single *.html Emscripten emitted if omitted.
+set -e
+
+BUILD="$PWD/build/wasm"
+[ -d "$BUILD" ] || { echo "error: $BUILD not found — build first (see build-wasm.sh)" >&2; exit 1; }
+
+# Determine the Emscripten target's base name (e.g. "Beach" -> Beach.html/.js/.wasm).
+if [ -n "$1" ]; then
+  NAME="$1"
+else
+  htmls=("$BUILD"/*.html)
+  if [ ! -e "${htmls[0]}" ]; then
+    echo "error: no *.html in $BUILD — build first" >&2; exit 1
+  elif [ "${#htmls[@]}" -gt 1 ]; then
+    echo "error: multiple *.html in $BUILD; pass the exe name explicitly" >&2; exit 1
+  fi
+  NAME="$(basename "${htmls[0]}" .html)"
+fi
+
+for f in "$NAME.html" "$NAME.js" "$NAME.wasm"; do
+  [ -f "$BUILD/$f" ] || { echo "error: $BUILD/$f not found — build first" >&2; exit 1; }
+done
+
+OUT="$BUILD/$(echo "$NAME" | tr '[:upper:]' '[:lower:]').zip"
+
+# Stage in a temp dir so <Exe>.html can be renamed to index.html without touching
+# the build outputs (zip has no in-place rename).
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+cp "$BUILD/$NAME.html" "$STAGE/index.html"
+cp "$BUILD/$NAME.js"   "$STAGE/$NAME.js"
+cp "$BUILD/$NAME.wasm" "$STAGE/$NAME.wasm"
+
+rm -f "$OUT"
+( cd "$STAGE" && zip -q "$OUT" index.html "$NAME.js" "$NAME.wasm" )
+
+echo "Done: $OUT"
+unzip -l "$OUT"

--- a/web/serve-wasm.py
+++ b/web/serve-wasm.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Serve a timeless game's WASM build locally with the cross-origin isolation
+headers that SharedArrayBuffer (and therefore the pthreads/threaded-FMOD build)
+requires. Run from the GAME's repo root (it serves ./build/wasm).
+
+Plain `python3 -m http.server` does NOT send these headers, so the threaded
+build will fail to start under it (SharedArrayBuffer is undefined). itch.io's
+"SharedArrayBuffer support" checkbox sets the same headers in production.
+
+Usage:  cd <game-repo> && /path/to/timeless/web/serve-wasm.py [port]
+        then open the printed http://localhost:<port>/<Exe>.html URL
+"""
+import glob
+import http.server
+import os
+import socketserver
+import sys
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+DIRECTORY = "build/wasm"
+
+
+class COIHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+
+entry = sorted(os.path.basename(p) for p in glob.glob(f"{DIRECTORY}/*.html"))
+entry_name = entry[0] if entry else "index.html"
+
+with socketserver.TCPServer(("", PORT), COIHandler) as httpd:
+    print(f"Serving {DIRECTORY}/ with COOP+COEP at http://localhost:{PORT}/{entry_name}")
+    print("In the page console, self.crossOriginIsolated should be true.")
+    httpd.serve_forever()

--- a/web/shell.html
+++ b/web/shell.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <!-- Default Emscripten shell for timeless games (see web/README.md). Wired
+         in automatically via timeless's PUBLIC --shell-file link option. A game
+         that wants its own branding can point --shell-file at its own copy. -->
+    <style>
+    body {
+      font-family: arial;
+      margin: 0;
+      padding: 0;
+      background-color: #0d0d0d;
+      color: white;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    h1, p{ text-align: center;}
+
+    .emscripten { padding-right: 0; display: block; }
+    div.emscripten { text-align: center; }
+    div.emscripten_border { border: 1px solid black; }
+    canvas.emscripten { border: 0px none; background-color: black; }
+
+    #fullscreen-btn {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      z-index: 10;
+      background: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.5);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+    #fullscreen-btn:hover {
+      background: rgba(255, 255, 255, 0.18);
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    /* Click-to-start overlay: the browser blocks audio until a user gesture, so
+       the game's main loop holds its simulation until #start-overlay is clicked.
+       This covers the canvas so the player knows to click and so nothing of the
+       intro is seen before audio is unlocked. */
+    #start-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0d0d0d;
+      cursor: pointer;
+      font-size: 28px;
+      letter-spacing: 0.05em;
+      color: rgba(255, 255, 255, 0.85);
+      user-select: none;
+    }
+    #start-overlay.hidden { display: none; }
+    </style>
+</head>
+
+<body>
+    <!-- Create the canvas that the C++ code will draw into -->
+    <div id="canvas-wrapper">
+      <canvas width="1920" height="1080" class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <input id="fullscreen-btn" type="button" value="⛶ Fullscreen" onclick="goFullscreen()">
+    <div id="start-overlay">Loading…</div>
+
+    <!-- Allow the C++ to access the canvas element -->
+    <script type='text/javascript'>
+        // Track every AudioContext the page creates. FMOD makes its own context
+        // during init; to unlock audio we must resume *that* exact context, not a
+        // throwaway one. Patch the constructor here — before the Emscripten module
+        // (and thus FMOD) loads — so every instance is recorded in _audioContexts.
+        (function() {
+            var Native = window.AudioContext || window.webkitAudioContext;
+            if (!Native) return;
+            window._audioContexts = [];
+            var Patched = new Proxy(Native, {
+                construct: function(target, args) {
+                    var ctx = new target(...args);
+                    window._audioContexts.push(ctx);
+                    return ctx;
+                }
+            });
+            window.AudioContext = Patched;
+            if (window.webkitAudioContext) window.webkitAudioContext = Patched;
+        })();
+
+        var Module = {
+            canvas: (function() { return document.getElementById('canvas'); })(),
+            // Marks when the wasm runtime is up (FMOD initialises just after, in
+            // main()). The start gate uses this — not time-since-click — to decide
+            // audio is unavailable, so a slow (large) download doesn't trip the
+            // fallback before FMOD has had a chance to create its context.
+            onRuntimeInitialized: function() { window._runtimeReady = Date.now(); }
+        };
+
+        function applyCanvasScale() {
+            var canvas = document.getElementById('canvas');
+            // Use the actual canvas buffer size as the reference so that platforms
+            // like itch.io (which constrain the iframe to e.g. 1280x720 and have
+            // Emscripten set canvas.width/height accordingly) are handled correctly.
+            // Fall back to 1920x1080 only before the canvas is initialised.
+            var canvasW = canvas.width > 0 ? canvas.width : 1920;
+            var canvasH = canvas.height > 0 ? canvas.height : 1080;
+            // Fit the fixed-resolution canvas into the available space, preserving
+            // aspect ratio (letterbox). No upper cap: timeless renders at a fixed
+            // backing store, so to actually fill a fullscreen (or larger) viewport
+            // we must be allowed to scale ABOVE 1.0 — capping at 1.0 left the canvas
+            // at native size with black bars filling the rest.
+            var scale = Math.min(window.innerWidth / canvasW, window.innerHeight / canvasH);
+            var wrapper = document.getElementById('canvas-wrapper');
+            var targetTransform = 'scale(' + scale + ')';
+            var targetW = Math.round(canvasW * scale) + 'px';
+            var targetH = Math.round(canvasH * scale) + 'px';
+
+            // Size the wrapper to the visual dimensions for correct page layout.
+            wrapper.style.width = targetW;
+            wrapper.style.height = targetH;
+            wrapper.style.overflow = 'hidden';
+
+            // Scale the canvas visually via transform, NOT via style.width/height.
+            // Reason: Emscripten overrides Browser.calculateMouseCoords with a
+            // version that uses canvas.clientWidth (CSS layout size). If we change
+            // style.width, clientWidth shrinks and the ratio clientWidth/rect.width = 1
+            // — no correction, mouse coords are in CSS pixels not buffer pixels.
+            // With transform: scale(), clientWidth stays at the buffer width but
+            // getBoundingClientRect().width = visual size, so the ratio correctly
+            // maps visual clicks back to buffer coordinates.
+            if (canvas.style.transform !== targetTransform) {
+                canvas.style.transform = targetTransform;
+                canvas.style.transformOrigin = 'top left';
+            }
+        }
+        applyCanvasScale();
+        window.addEventListener('resize', applyCanvasScale);
+
+        // Use the native Fullscreen API on the document root rather than
+        // Module.requestFullscreen: Emscripten's version resizes/repositions the
+        // canvas backing store and fights applyCanvasScale, which left the canvas
+        // at native size on a black screen. The body is flex-centered on black, so
+        // fullscreening the root and letting applyCanvasScale upscale the canvas
+        // gives a centered, letterboxed, full-screen image.
+        function goFullscreen() {
+            var el = document.documentElement;
+            var req = el.requestFullscreen || el.webkitRequestFullscreen ||
+                      el.mozRequestFullScreen || el.msRequestFullscreen;
+            if (req) {
+                var r = req.call(el);
+                if (r && r.catch) r.catch(function() {});
+            }
+        }
+        // The fullscreen transition fires resize, but re-apply explicitly too in
+        // case innerWidth/Height settle a frame late.
+        ['fullscreenchange', 'webkitfullscreenchange'].forEach(function(ev) {
+            document.addEventListener(ev, function() { setTimeout(applyCanvasScale, 50); });
+        });
+
+        // Emscripten's canvas setup sets canvas.style.width/height, triggering this
+        // observer. Re-apply our scale transform each time. The transform-equality
+        // guard above prevents loops.
+        (function() {
+            var canvas = document.getElementById('canvas');
+            var obs = new MutationObserver(function() {
+                applyCanvasScale();
+            });
+            obs.observe(canvas, { attributes: true, attributeFilter: ['style'] });
+        })();
+
+        // Resume every tracked AudioContext that's still suspended. Safe to call
+        // repeatedly; once the page has a user gesture (sticky activation), these
+        // resume() calls succeed even outside an event handler.
+        function resumeAllAudio() {
+            (window._audioContexts || []).forEach(function(ctx) {
+                if (ctx && ctx.state !== 'running' && ctx.resume) {
+                    ctx.resume().catch(function() {});
+                }
+            });
+        }
+        document.addEventListener('click', resumeAllAudio);
+        document.addEventListener('keydown', resumeAllAudio);
+
+        // FMOD's output AudioContext, once the module has created it.
+        function fmodContext() {
+            var M = window.Module || {};
+            return M.mContext || M.context || (M.SDL2 && M.SDL2.audioContext) || null;
+        }
+
+        // Start gate. The game's main loop must freeze its simulation until
+        // window._timelessStarted is true (poll it via emscripten_run_script_int;
+        // see beach/app.hpp for the reference implementation). Two hard browser
+        // rules drive the design here:
+        //   1. Audio can only be unlocked by a user gesture in THIS iframe's
+        //      document. itch's "Run game" click is in the parent page and does
+        //      not count, so we need our own click.
+        //   2. AudioContext.resume() must be called *synchronously inside* that
+        //      gesture handler. Resuming from a timer/promise later does NOT work
+        //      in a cross-origin iframe even after a prior gesture — that was why
+        //      audio stayed silent until a second manual click.
+        // So we can't start on the first click if FMOD hasn't created its context
+        // yet (a fast click beats the large wasm load). Instead we wait until the
+        // context exists, THEN enable the prompt, so the click that starts the game
+        // also resumes the context in-handler.
+        var overlay = document.getElementById('start-overlay');
+        window._timelessStarted = false;
+        var audioReady = false;
+
+        var waitAudio = setInterval(function() {
+            var ctx = fmodContext();
+            // No context yet, but the runtime has been up a while → audio is
+            // unavailable (e.g. no sound banks); allow starting without it.
+            var noAudio = !ctx && window._runtimeReady &&
+                          Date.now() - window._runtimeReady > 5000;
+            if (ctx || noAudio) {
+                clearInterval(waitAudio);
+                audioReady = true;
+                overlay.textContent = '▶ Click to start';
+            }
+        }, 100);
+
+        function startGame() {
+            if (window._timelessStarted) return;
+            if (!audioReady) return; // still loading — ignore early clicks
+            function begin() {
+                window._timelessStarted = true;
+                overlay.classList.add('hidden');
+            }
+            var ctx = fmodContext();
+            // Must call resume() right here, in the gesture, for the iframe to
+            // actually unlock audio. begin() either way so a no-audio build starts.
+            if (ctx && ctx.resume) ctx.resume().then(begin, begin);
+            else begin();
+        }
+        overlay.addEventListener('click', startGame);
+
+</script>
+
+    <!-- Add the javascript glue code (index.js) as generated by Emscripten -->
+    {{{ SCRIPT }}}
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

Replaces **GLFW** with **SDL2** for windowing, GL-context creation, input, and timing — hidden behind an engine-owned abstraction so neither GLFW nor SDL types appear in any public header. Keeps the WebAssembly/Emscripten build working.

## What changed

- **New `input.hpp`** — engine-owned `te::Key` / `te::MouseButton` enums + `te::now_seconds()`. The only backend-agnostic input surface; the GLFW/SDL scancode mapping lives in `window_manager.cpp`.
- **WindowManager rewritten on SDL2 (PIMPL)** — `SDL_Window`/`SDL_GLContext`/`SDL_Cursor` live behind an opaque `PlatformWindow` defined only in the `.cpp`. New public methods: `swap_buffers`, `poll_events`, `should_close`, `is_key_pressed`, `is_mouse_button_pressed`, `get_cursor_position`, `set_cursor_visible`.
- **Event pump** — the three GLFW mouse callbacks became an `SDL_PollEvent` loop in `poll_events()` that emits the **same string events** (`"LeftMousePress"`, `"MouseMove"`, …), so no downstream event-listener code changes. Coordinate-mapping math is preserved.
- **Signatures** — `GLFWwindow*` → `WindowManager&` in `System::update`, `Scene::init`/`init_step`, `TE::loop`, and the keyboard/movement systems. All `glfwGetTime()` → `te::now_seconds()`.
- **Build** — SDL 2.30.12 added as `vendor/sdl` submodule; desktop links `SDL2-static`; Emscripten uses `-sUSE_SDL=2` at **both** compile and link (the compile flag is required by the SDL port; GLFW didn't need it).

## Verification

- ✅ Desktop: `timeless`, `example` build; the downstream Beach game builds, opens an SDL window, initializes GL, loads the map and renders.
- ✅ WASM: `timeless` library compiles + links under `emcc` with the SDL2 port.
- ✅ Zero functional GLFW references remain (only comments mention it).

> Note: a companion PR in the `beach` repo bumps the submodule pointer and ports the game scenes. Merge this PR first, then update the submodule pointer there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)